### PR TITLE
feat: 랜딩 페이지 UI 구현

### DIFF
--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -2,8 +2,17 @@ import React from "react";
 import Header from "../components/header/Header";
 import { Link } from "react-router-dom";
 import { IoCodeOutline } from "react-icons/io5";
+import { PiUsersFour } from "react-icons/pi";
+import { VscFeedback } from "react-icons/vsc";
 
 function Landing() {
+  // 랜딩 페이지 통계 영역 데이터 (추후 백엔드 연동 예정)
+  const stats = [
+    { icon: IoCodeOutline, value: "1,234", label: "심어진 새싹" },
+    { icon: PiUsersFour, value: "567", label: "활성 가드너" },
+    { icon: VscFeedback, value: "8,901", label: "피드백" },
+  ];
+
   return (
     <div>
       <Header />
@@ -23,7 +32,7 @@ function Landing() {
         </div>
 
         {/* 버튼 */}
-        <div className="flex justify-center gap-6 text-[20px] text-white pt-16">
+        <div className="flex justify-center gap-6 text-[20px] text-white pt-12">
           <Link
             className="w-[250px] h-[63px] bg-[#16A34A] rounded-[6px] hover:bg-[#2bad5b] flex items-center justify-center space-x-2 text-white font-medium"
             to="/upload"
@@ -37,6 +46,23 @@ function Landing() {
           >
             정원 둘러보기
           </Link>
+        </div>
+
+        {/* 통계 영역 */}
+        <div className="flex justify-center space-x-44 pt-20">
+          {stats.map(({ icon: Icon, value, label }) => (
+            <div key={label} className="flex flex-col items-center">
+              <div className="flex justify-center items-center w-[80px] h-[80px] bg-white rounded-[12px] shadow-sm">
+                <Icon size={40} className="text-[#16A34A]" />
+              </div>
+              <div className="text-[36px] font-bold text-black pt-2">
+                {value}
+              </div>
+              <div className="text-[#4D4D4D] text-[24px] font-semibold">
+                {label}
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import Header from "../components/header/Header";
+import { Link } from "react-router-dom";
+import { IoCodeOutline } from "react-icons/io5";
 
 function Landing() {
   return (
@@ -18,6 +20,23 @@ function Landing() {
           <span className="flex justify-center text-[20px] text-[#626262]">
             정원에 새싹을 심고 가꿔보세요.
           </span>
+        </div>
+
+        {/* 버튼 */}
+        <div className="flex justify-center gap-6 text-[20px] text-white pt-16">
+          <Link
+            className="w-[250px] h-[63px] bg-[#16A34A] rounded-[6px] hover:bg-[#2bad5b] flex items-center justify-center space-x-2 text-white font-medium"
+            to="/upload"
+          >
+            <IoCodeOutline size={22} />
+            <span>새싹 심기 시작하기</span>
+          </Link>
+          <Link
+            className="w-[149px] h-[63px] bg-[#4D4D4D] rounded-[6px] hover:bg-[#575757] flex items-center justify-center"
+            to="/posts"
+          >
+            정원 둘러보기
+          </Link>
         </div>
       </div>
     </div>

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,14 +1,27 @@
-import React from 'react'
+import React from "react";
+import Header from "../components/header/Header";
 
 function Landing() {
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-semibold">Landing</h1>
-      <p>랜딩 페이지</p>
+    <div>
+      <Header />
+      <div className="w-full h-[868px] bg-gradient-to-r from-[#F0FDF4] to-[#BDF7D1]">
+        {/* 텍스트 영역 */}
+        <div>
+          <h2 className="flex justify-center text-[50px] text-[#4D4D4D] font-bold pt-20">
+            새싹을 심고, 함께 가꾸고, 함께 성장하세요
+          </h2>
+          <span className="flex justify-center text-[20px] text-[#626262] pt-6">
+            AI와 동료 개발자들과 함께 새싹를 리뷰하고 피드백을 받으며, 더 나은
+            개발자로 성장해보세요.
+          </span>
+          <span className="flex justify-center text-[20px] text-[#626262]">
+            정원에 새싹을 심고 가꿔보세요.
+          </span>
+        </div>
+      </div>
     </div>
-  )
+  );
 }
 
-export default Landing
-
-
+export default Landing;


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 랜딩 페이지 UI 구현
## 🔧 주요 변경 내용
<!-- 주요 변경사항들을 나열해주세요 -->
- 서비스 소개 텍스트 추가
- `<> 새싹 심기 시작하기` 버튼 클릭 -> 게시물 등록 페이지로 이동 (`/upload`)
- `정원 둘러보기` 버튼 클릭 -> 게시물 목록 페이지로 이동 (`/posts`)
- 통계 영역 -> 추후 백엔드 연동 필요
   - 심어진 새싹 : 등록된 게시물 수
   - 활성 가드너 : 가입된 사용자 수
   - 피드백 : 등록된 피드백 수

## 📸 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1885" height="926" alt="image" src="https://github.com/user-attachments/assets/179af056-41e8-4907-a7b2-11dbe56d34b5" />

## 🔗 관련 이슈
Closes #8  