### PR TITLE
feat: 게시물 상세 페이지 UI 구현

### DIFF
--- a/src/components/feedbackContext.jsx
+++ b/src/components/feedbackContext.jsx
@@ -1,0 +1,98 @@
+// 피드백 샘플 데이터
+
+export const sampleFeedbacks = [
+  {
+    id: 101,
+    postId: 1,
+    author: '농담곰',
+    avatarInitial: '농',
+    timeAgo: '3시간 전',
+    rating: 5,
+    content:
+      '성능 최적화 측면에서 몇 가지 개선점이 있습니다. filteredTodos 계산을 useMemo로 감싸고, 이벤트 핸들러들을 useCallback으로 최적화하면 리렌더링을 줄일 수 있을 것 같습니다.',
+    likes: 23,
+    comments: 13,
+    views: 237,
+  },
+  {
+    id: 102,
+    postId: 1,
+    author: '농담곰',
+    avatarInitial: '농',
+    timeAgo: '5시간 전',
+    rating: 5,
+    content:
+      '상태 업데이트 로직에서 불변성을 지키도록 도우미 함수를 분리해두면 가독성이 좋아집니다. reducer를 사용할 경우 action 타입을 상수로 관리해보세요.',
+    likes: 19,
+    comments: 8,
+    views: 180,
+  },
+  {
+    id: 103,
+    postId: 1,
+    author: '코드리뷰어',
+    avatarInitial: '코',
+    timeAgo: '7시간 전',
+    rating: 4,
+    content:
+      '컴포넌트 분리를 통해 책임을 줄이고 테스트 가능성을 높이면 유지보수가 쉬워집니다. 특히 리스트/아이템을 분리해보세요.',
+    likes: 12,
+    comments: 3,
+    views: 120,
+  },
+  {
+    id: 104,
+    postId: 1,
+    author: '프런트J',
+    avatarInitial: '프',
+    timeAgo: '8시간 전',
+    rating: 3,
+    content:
+      'CSS가 전역에 퍼져 있어 예상치 못한 사이드이펙트가 있습니다. Tailwind 프리셋을 통일하거나 CSS Module을 고려해 보세요.',
+    likes: 7,
+    comments: 1,
+    views: 88,
+  },
+  {
+    id: 105,
+    postId: 1,
+    author: '테스트러',
+    avatarInitial: '테',
+    timeAgo: '어제',
+    rating: 5,
+    content:
+      '중요 훅에 대한 단위 테스트를 추가하면 리팩토링 시 안정성이 커집니다. react-testing-library 예제가 있으면 더 좋겠어요.',
+    likes: 15,
+    comments: 5,
+    views: 140,
+  },
+  {
+    id: 106,
+    postId: 1,
+    author: 'UX연구원',
+    avatarInitial: 'UX',
+    timeAgo: '2일 전',
+    rating: 4,
+    content:
+      '폼 에러 메시지의 접근성 레이블이 부족합니다. aria-describedby로 연결하면 스크린리더 호환성이 좋아집니다.',
+    likes: 10,
+    comments: 2,
+    views: 101,
+  },
+  {
+    id: 201,
+    postId: 2,
+    author: '리액트팬',
+    avatarInitial: '리',
+    timeAgo: '1일 전',
+    rating: 4,
+    content: '네이티브 모듈 브리징 관련해서 샘플 코드가 있으면 더 좋겠습니다.',
+    likes: 11,
+    comments: 2,
+    views: 95,
+  },
+]
+
+export default sampleFeedbacks
+
+

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,10 +1,212 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { FaHeart, FaComment, FaEye, FaStar } from 'react-icons/fa'
+import Header from '../components/header/Header'
+import { useParams } from 'react-router-dom'
+import { samplePosts } from '../components/postcontext'
 
 function PostDetail() {
+  const { postId } = useParams()
+  const idNum = Number(postId)
+  const post = (Number.isNaN(idNum)
+    ? samplePosts[0]
+    : samplePosts.find(p => p.id === idNum)) || samplePosts[0]
+  const [selectedFeedbackType, setSelectedFeedbackType] = useState('일반 피드백')
+  const [rating, setRating] = useState(5)
+  const [feedbackContent, setFeedbackContent] = useState('')
+
+  const feedbackTypes = ['일반 피드백', '개선 제안', '버그 신고']
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-semibold">Post Detail</h1>
-      <p>게시물 상세 페이지</p>
+    <div className="min-h-screen bg-[#F9FAFB]">
+      <Header />
+      
+      <div className="max-w-7xl mx-auto px-4 py-8">
+        {/* 게시물 정보 카드 */}
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-8">
+          {/* 게시물 제목 */}
+          <h1 className="text-2xl font-bold text-gray-800 mb-4">
+            {post.title}
+          </h1>
+          {/* 게시물 설명 */}
+          <p className="text-gray-600 mb-6 leading-relaxed">
+            {post.content}
+          </p>
+          {/* 작성자 정보 */}
+          <div className="flex items-center mb-6">
+            <div className="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center text-white font-semibold mr-3">
+              {post.avatar || '👤'}
+            </div>
+            <div>
+              <p className="font-semibold text-gray-900">{post.author}</p>
+              <p className="text-sm text-gray-500">{post.timeAgo}</p>
+            </div>
+          </div>
+          {/* 태그 */}
+          <div className="flex flex-wrap gap-2 mb-6">
+            {post.tags?.map((tag) => (
+              <span 
+                key={tag}
+                className="px-3 py-1 bg-green-100 text-green-800 rounded-full text-sm"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+          
+          {/* 통계 */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-6 mb-0">
+              <div className="flex items-center space-x-2 text-gray-600">
+                <FaHeart className="text-red-500" />
+                <span>{post.likes}</span>
+              </div>
+              <div className="flex items-center space-x-2 text-gray-600">
+                <FaComment className="text-blue-500" />
+                <span>{post.comments}</span>
+              </div>
+              <div className="flex items-center space-x-2 text-gray-600">
+                <FaEye className="text-gray-500" />
+                <span>{post.views}</span>
+              </div>
+            </div>
+            <div>
+              <button className='bg-green-600 text-white px-4 py-2 rounded-md'>AI 피드백</button>
+            </div>
+          </div>
+        </div>
+
+        {/* 하단 */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          {/*코드 에디터 */}
+          <div className="lg:col-span-2">
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"> 코드에디터 </div>
+          </div>
+
+          {/* 피드백 요청 + 작성 + 기존 피드백 */}
+          <div className="lg:col-span-1">
+            <div className="space-y-6">
+              {/* 피드백 요청 */}
+              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4">피드백 요청</h3>
+                <div className="space-y-2">
+                  {[
+                    '성능 최적화에 대한 피드백을 원합니다',
+                    '코드 구조 개선 방안을 알고 싶습니다',
+                    '접근성(Accessibility) 개선 제안을 받고 싶습니다'
+                  ].map((request, index) => (
+                    <div
+                      key={index}
+                      className="text-sm text-gray-700 px-3 py-2 bg-gray-50 border border-gray-200 rounded"
+                    >
+                      {request}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* 피드백 작성 */}
+              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4">피드백 작성</h3>
+                {/* 피드백 유형 */}
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 유형</label>
+                  <div className="flex space-x-2">
+                    {feedbackTypes.map((type) => (
+                      <button
+                        key={type}
+                        onClick={() => setSelectedFeedbackType(type)}
+                        className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                          selectedFeedbackType === type
+                            ? 'bg-green-600 text-white'
+                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                        }`}
+                      >
+                        {type}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                {/* 평점 */}
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">평점</label>
+                  <div className="flex space-x-1">
+                    {[1, 2, 3, 4, 5].map((star) => (
+                      <button
+                        key={star}
+                        onClick={() => setRating(star)}
+                        className="text-2xl transition-colors"
+                      >
+                        <FaStar 
+                          className={star <= rating ? 'text-yellow-400' : 'text-gray-300'} 
+                        />
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                {/* 피드백 내용 */}
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 내용</label>
+                  <textarea
+                    value={feedbackContent}
+                    onChange={(e) => setFeedbackContent(e.target.value)}
+                    placeholder="새싹에 대한 피드백을 작성해주세요. 구체적이고 건설적인 피드백이 도움이 됩니다."
+                    rows="4"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none resize-none"
+                  />
+                  <p className="text-sm text-gray-500 mt-1">{feedbackContent.length}/1000자</p>
+                </div>
+                {/* 제출 버튼 */}
+                <button className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors">
+                  피드백 제출
+                </button>
+              </div>
+
+              {/* 기존 피드백 댓글 */}
+              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4">기존 피드백</h3>
+                <div className="space-y-4">
+                  {[1, 2].map((comment) => (
+                    <div key={comment} className="border-b border-gray-200 pb-4 last:border-b-0">
+                      <div className="flex items-center mb-2">
+                        <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-semibold mr-2">
+                          농
+                        </div>
+                        <div>
+                          <p className="font-semibold text-gray-900 text-sm">농담곰</p>
+                          <p className="text-xs text-gray-500">3시간 전</p>
+                        </div>
+                      </div>
+                      <div className="flex mb-2">
+                        {[1, 2, 3, 4, 5].map((star) => (
+                          <FaStar key={star} className="text-yellow-400 text-sm" />
+                        ))}
+                      </div>
+                      <p className="text-gray-700 text-sm leading-relaxed mb-3">
+                        성능 최적화 측면에서 몇 가지 개선점이 있습니다. filteredTodos 계산을 useMemo로 감싸고, 
+                        이벤트 핸들러들을 useCallback으로 최적화하면 리렌더링을 줄일 수 있을 것 같습니다.
+                      </p>
+                      <div className="flex items-center space-x-4 text-sm text-gray-500">
+                        <div className="flex items-center space-x-1">
+                          <FaHeart className="text-red-500" />
+                          <span>23</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                          <FaComment className="text-blue-500" />
+                          <span>13</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                          <FaEye className="text-gray-500" />
+                          <span>237</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -16,6 +16,7 @@ function PostDetail() {
   const [feedbackContent, setFeedbackContent] = useState('')
   const [showAllFeedbacks, setShowAllFeedbacks] = useState(false)
   const [feedbackSort, setFeedbackSort] = useState('latest')
+  const [isFeedbackFormOpen, setIsFeedbackFormOpen] = useState(false)
 
   const [postLiked, setPostLiked] = useState(Boolean(post.isLiked))
   const [postBookmarked, setPostBookmarked] = useState(Boolean(post.isBookmarked))
@@ -170,58 +171,79 @@ function PostDetail() {
               {/* 피드백 작성 */}
               <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">피드백 작성</h3>
-                {/* 피드백 유형 */}
-                <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 유형</label>
-                  <div className="flex space-x-2">
-                    {feedbackTypes.map((type) => (
-                      <button
-                        key={type}
-                        onClick={() => setSelectedFeedbackType(type)}
-                        className={`px-3 py-1 text-sm rounded-md transition-colors ${
-                          selectedFeedbackType === type
-                            ? 'bg-green-600 text-white'
-                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                        }`}
-                      >
-                        {type}
+                {!isFeedbackFormOpen ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsFeedbackFormOpen(true)}
+                    className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors"
+                  >
+                    피드백 작성하기
+                  </button>
+                ) : (
+                  <div>
+                    {/* 피드백 유형 */}
+                    <div className="mb-4">
+                      <label className="block text-sm font-medium text-gray-700 mb-2">피드백 유형</label>
+                      <div className="flex space-x-2">
+                        {feedbackTypes.map((type) => (
+                          <button
+                            key={type}
+                            onClick={() => setSelectedFeedbackType(type)}
+                            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                              selectedFeedbackType === type
+                                ? 'bg-green-600 text-white'
+                                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                            }`}
+                          >
+                            {type}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    {/* 평점 */}
+                    <div className="mb-4">
+                      <label className="block text-sm font-medium text-gray-700 mb-2">평점</label>
+                      <div className="flex space-x-1">
+                        {[1, 2, 3, 4, 5].map((star) => (
+                          <button
+                            key={star}
+                            onClick={() => setRating(star)}
+                            className="text-2xl transition-colors"
+                          >
+                            <FaStar 
+                              className={star <= rating ? 'text-yellow-400' : 'text-gray-300'} 
+                            />
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    {/* 피드백 내용 */}
+                    <div className="mb-4">
+                      <label className="block text-sm font-medium text-gray-700 mb-2">피드백 내용</label>
+                      <textarea
+                        value={feedbackContent}
+                        onChange={(e) => setFeedbackContent(e.target.value)}
+                        placeholder="새싹에 대한 피드백을 작성해주세요. 구체적이고 건설적인 피드백이 도움이 됩니다."
+                        rows="4"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none resize-none"
+                      />
+                      <p className="text-sm text-gray-500 mt-1">{feedbackContent.length}/1000자</p>
+                    </div>
+                    {/* 제출/취소 */}
+                    <div className="flex gap-2">
+                      <button className="flex-1 bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors">
+                        피드백 제출
                       </button>
-                    ))}
-                  </div>
-                </div>
-                {/* 평점 */}
-                <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">평점</label>
-                  <div className="flex space-x-1">
-                    {[1, 2, 3, 4, 5].map((star) => (
                       <button
-                        key={star}
-                        onClick={() => setRating(star)}
-                        className="text-2xl transition-colors"
+                        type="button"
+                        onClick={() => setIsFeedbackFormOpen(false)}
+                        className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
                       >
-                        <FaStar 
-                          className={star <= rating ? 'text-yellow-400' : 'text-gray-300'} 
-                        />
+                        취소
                       </button>
-                    ))}
+                    </div>
                   </div>
-                </div>
-                {/* 피드백 내용 */}
-                <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 내용</label>
-                  <textarea
-                    value={feedbackContent}
-                    onChange={(e) => setFeedbackContent(e.target.value)}
-                    placeholder="새싹에 대한 피드백을 작성해주세요. 구체적이고 건설적인 피드백이 도움이 됩니다."
-                    rows="4"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none resize-none"
-                  />
-                  <p className="text-sm text-gray-500 mt-1">{feedbackContent.length}/1000자</p>
-                </div>
-                {/* 제출 버튼 */}
-                <button className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors">
-                  피드백 제출
-                </button>
+                )}
               </div>
 
           {/* 기존 피드백 댓글 */}

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { FaHeart, FaComment, FaEye, FaStar } from 'react-icons/fa'
+import React, { useState, useEffect } from 'react'
+import { FaHeart, FaRegHeart, FaComment, FaEye, FaStar } from 'react-icons/fa'
 import Header from '../components/header/Header'
 import { useParams } from 'react-router-dom'
 import { samplePosts } from '../components/postcontext'
@@ -16,6 +16,26 @@ function PostDetail() {
   const [feedbackContent, setFeedbackContent] = useState('')
   const [showAllFeedbacks, setShowAllFeedbacks] = useState(false)
   const [feedbackSort, setFeedbackSort] = useState('latest')
+  const [feedbackItems, setFeedbackItems] = useState([])
+  const [isFeedbackFormOpen, setIsFeedbackFormOpen] = useState(false)
+
+  useEffect(() => {
+    const nextItems = sampleFeedbacks
+      .filter(f => f.postId === post.id)
+      .map(f => ({ ...f, isLiked: Boolean(f.isLiked) }))
+    setFeedbackItems(nextItems)
+  }, [post.id])
+
+  const toggleFeedbackLike = (feedbackId) => {
+    setFeedbackItems(items =>
+      items.map(item => {
+        if (item.id !== feedbackId) return item
+        const nextLiked = !item.isLiked
+        const nextLikes = item.likes + (nextLiked ? 1 : -1)
+        return { ...item, isLiked: nextLiked, likes: nextLikes }
+      })
+    )
+  }
 
   const feedbackTypes = ['일반 피드백', '개선 제안', '버그 신고']
 
@@ -110,58 +130,79 @@ function PostDetail() {
               {/* 피드백 작성 */}
               <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">피드백 작성</h3>
-                {/* 피드백 유형 */}
-                <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 유형</label>
-                  <div className="flex space-x-2">
-                    {feedbackTypes.map((type) => (
-                      <button
-                        key={type}
-                        onClick={() => setSelectedFeedbackType(type)}
-                        className={`px-3 py-1 text-sm rounded-md transition-colors ${
-                          selectedFeedbackType === type
-                            ? 'bg-green-600 text-white'
-                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                        }`}
-                      >
-                        {type}
+                {!isFeedbackFormOpen ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsFeedbackFormOpen(true)}
+                    className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors"
+                  >
+                    피드백 작성하기
+                  </button>
+                ) : (
+                  <>
+                    {/* 피드백 유형 */}
+                    <div className="mb-4">
+                      <label className="block text-sm font-medium text-gray-700 mb-2">피드백 유형</label>
+                      <div className="flex space-x-2">
+                        {feedbackTypes.map((type) => (
+                          <button
+                            key={type}
+                            onClick={() => setSelectedFeedbackType(type)}
+                            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                              selectedFeedbackType === type
+                                ? 'bg-green-600 text-white'
+                                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                            }`}
+                          >
+                            {type}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    {/* 평점 */}
+                    <div className="mb-4">
+                      <label className="block text-sm font-medium text-gray-700 mb-2">평점</label>
+                      <div className="flex space-x-1">
+                        {[1, 2, 3, 4, 5].map((star) => (
+                          <button
+                            key={star}
+                            onClick={() => setRating(star)}
+                            className="text-2xl transition-colors"
+                          >
+                            <FaStar 
+                              className={star <= rating ? 'text-yellow-400' : 'text-gray-300'} 
+                            />
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    {/* 피드백 내용 */}
+                    <div className="mb-4">
+                      <label className="block text-sm font-medium text-gray-700 mb-2">피드백 내용</label>
+                      <textarea
+                        value={feedbackContent}
+                        onChange={(e) => setFeedbackContent(e.target.value)}
+                        placeholder="새싹에 대한 피드백을 작성해주세요. 구체적이고 건설적인 피드백이 도움이 됩니다."
+                        rows="4"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none resize-none"
+                      />
+                      <p className="text-sm text-gray-500 mt-1">{feedbackContent.length}/1000자</p>
+                    </div>
+                    {/* 제출/취소 */}
+                    <div className="flex gap-2">
+                      <button className="flex-1 bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors">
+                        피드백 제출
                       </button>
-                    ))}
-                  </div>
-                </div>
-                {/* 평점 */}
-                <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">평점</label>
-                  <div className="flex space-x-1">
-                    {[1, 2, 3, 4, 5].map((star) => (
                       <button
-                        key={star}
-                        onClick={() => setRating(star)}
-                        className="text-2xl transition-colors"
+                        type="button"
+                        onClick={() => setIsFeedbackFormOpen(false)}
+                        className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
                       >
-                        <FaStar 
-                          className={star <= rating ? 'text-yellow-400' : 'text-gray-300'} 
-                        />
+                        취소
                       </button>
-                    ))}
-                  </div>
-                </div>
-                {/* 피드백 내용 */}
-                <div className="mb-4">
-                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 내용</label>
-                  <textarea
-                    value={feedbackContent}
-                    onChange={(e) => setFeedbackContent(e.target.value)}
-                    placeholder="새싹에 대한 피드백을 작성해주세요. 구체적이고 건설적인 피드백이 도움이 됩니다."
-                    rows="4"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none resize-none"
-                  />
-                  <p className="text-sm text-gray-500 mt-1">{feedbackContent.length}/1000자</p>
-                </div>
-                {/* 제출 버튼 */}
-                <button className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors">
-                  피드백 제출
-                </button>
+                    </div>
+                  </>
+                )}
               </div>
 
           {/* 기존 피드백 댓글 */}
@@ -190,7 +231,7 @@ function PostDetail() {
 
             <div className="space-y-4">
               {(() => {
-                const all = sampleFeedbacks.filter(f => f.postId === post.id)
+                const all = feedbackItems
                 const INITIAL_COUNT = 4
                 const list = showAllFeedbacks ? all : all.slice(0, INITIAL_COUNT)
                 return list.map((fb) => (
@@ -214,13 +255,20 @@ function PostDetail() {
                         {fb.content}
                       </p>
                       <div className="flex items-center space-x-4 text-sm text-gray-500">
-                        <div className="flex items-center space-x-1">
-                          <FaHeart className="text-red-500" />
-                          <span>{fb.likes}</span>
-                        </div>
-                        <div className="flex items-center space-x-1">
-                          <FaComment className="text-blue-500" />
-                          <span>{fb.comments}</span>
+                        {/* 좋아요 */}
+                        <button
+                          type="button"
+                          onClick={() => toggleFeedbackLike(fb.id)}
+                          className="flex items-center space-x-1 text-gray-600 hover:text-red-500 transition-colors"
+                          aria-pressed={fb.isLiked}
+                        >
+                          {fb.isLiked ? <FaHeart className="text-red-500" /> : <FaRegHeart />}
+                          <span className="text-sm font-medium">{fb.likes}</span>
+                        </button>
+                        {/* 댓글 */}
+                        <div className="flex items-center space-x-1 text-gray-600">
+                          <FaComment />
+                          <span className="text-sm font-medium">{fb.comments}</span>
                         </div>
                         <div className="flex items-center space-x-1">
                           <FaEye className="text-gray-500" />
@@ -233,7 +281,7 @@ function PostDetail() {
               })()}
             </div>
             {(() => {
-              const total = sampleFeedbacks.filter(f => f.postId === post.id).length
+              const total = feedbackItems.length
               const INITIAL_COUNT = 4
               if (showAllFeedbacks || total <= INITIAL_COUNT) return null
               return (

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -24,21 +24,31 @@ function PostDetail() {
   const [postBookmarked, setPostBookmarked] = useState(Boolean(post.isBookmarked))
   const [postLikeCount, setPostLikeCount] = useState(post.likes ?? 0)
   const [postBookmarkCount, setPostBookmarkCount] = useState(post.bookmarks ?? 0)
+  const [likeBusy, setLikeBusy] = useState(false)
+  const [bookmarkBusy, setBookmarkBusy] = useState(false)
 
-  const togglePostLike = () => {
+  const togglePostLike = (e) => {
+    if (e && e.stopPropagation) e.stopPropagation()
+    if (likeBusy) return
+    setLikeBusy(true)
     setPostLiked(prev => {
       const next = !prev
       setPostLikeCount(c => c + (next ? 1 : -1))
       return next
     })
+    setTimeout(() => setLikeBusy(false), 200)
   }
 
-  const togglePostBookmark = () => {
+  const togglePostBookmark = (e) => {
+    if (e && e.stopPropagation) e.stopPropagation()
+    if (bookmarkBusy) return
+    setBookmarkBusy(true)
     setPostBookmarked(prev => {
       const next = !prev
       setPostBookmarkCount(c => c + (next ? 1 : -1))
       return next
     })
+    setTimeout(() => setBookmarkBusy(false), 200)
   }
 
   const [feedbackLikeState, setFeedbackLikeState] = useState({})
@@ -107,7 +117,7 @@ function PostDetail() {
               {/* 좋아요 */}
               <button
                 type="button"
-                onClick={togglePostLike}
+                onClick={(e) => togglePostLike(e)}
                 className="flex items-center space-x-2 text-gray-600 hover:text-red-500 transition-colors"
                 aria-pressed={postLiked}
               >
@@ -117,7 +127,7 @@ function PostDetail() {
               {/* 스크랩 */}
               <button
                 type="button"
-                onClick={togglePostBookmark}
+                onClick={(e) => togglePostBookmark(e)}
                 className="flex items-center space-x-2 text-gray-600 hover:text-blue-500 transition-colors"
                 aria-pressed={postBookmarked}
               >
@@ -317,7 +327,7 @@ function PostDetail() {
                       <div className="flex items-center space-x-4 text-sm text-gray-500">
                         <button
                           type="button"
-                          onClick={() => toggleFeedbackLike(fb.id)}
+                          onClick={(e) => { e.stopPropagation(); toggleFeedbackLike(fb.id) }}
                           className="flex items-center space-x-1 text-gray-600 hover:text-red-500 transition-colors"
                           aria-pressed={feedbackLikeState[fb.id]?.liked}
                         >

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -22,8 +22,6 @@ function PostDetail() {
 
   const [postLiked, setPostLiked] = useState(Boolean(post.isLiked))
   const [postBookmarked, setPostBookmarked] = useState(Boolean(post.isBookmarked))
-  const [postLikeCount, setPostLikeCount] = useState(post.likes ?? 0)
-  const [postBookmarkCount, setPostBookmarkCount] = useState(post.bookmarks ?? 0)
   const [likeBusy, setLikeBusy] = useState(false)
   const [bookmarkBusy, setBookmarkBusy] = useState(false)
 
@@ -31,11 +29,7 @@ function PostDetail() {
     if (e && e.stopPropagation) e.stopPropagation()
     if (likeBusy) return
     setLikeBusy(true)
-    setPostLiked(prev => {
-      const next = !prev
-      setPostLikeCount(c => c + (next ? 1 : -1))
-      return next
-    })
+    setPostLiked(prev => !prev)
     setTimeout(() => setLikeBusy(false), 200)
   }
 
@@ -43,11 +37,7 @@ function PostDetail() {
     if (e && e.stopPropagation) e.stopPropagation()
     if (bookmarkBusy) return
     setBookmarkBusy(true)
-    setPostBookmarked(prev => {
-      const next = !prev
-      setPostBookmarkCount(c => c + (next ? 1 : -1))
-      return next
-    })
+    setPostBookmarked(prev => !prev)
     setTimeout(() => setBookmarkBusy(false), 200)
   }
 
@@ -115,25 +105,35 @@ function PostDetail() {
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-6 mb-0">
               {/* 좋아요 */}
-              <button
-                type="button"
-                onClick={(e) => togglePostLike(e)}
-                className="flex items-center space-x-2 text-gray-600 hover:text-red-500 transition-colors"
-                aria-pressed={postLiked}
-              >
-                {postLiked ? <FaHeart className="text-red-500" /> : <FaRegHeart />}
-                <span>{postLikeCount}</span>
-              </button>
+               <button
+                 type="button"
+                 onClick={(e) => {
+                   e.preventDefault();
+                   e.stopPropagation();
+                   e.nativeEvent?.stopImmediatePropagation?.();
+                   togglePostLike(e);
+                 }}
+                 className="flex items-center space-x-2 text-gray-600 hover:text-red-500 transition-colors"
+                 aria-pressed={postLiked}
+               >
+                 {postLiked ? <FaHeart className="text-red-500" /> : <FaRegHeart />}
+                 <span>{postLiked ? (post.likes ?? 0) + 1 : (post.likes ?? 0)}</span>
+               </button>
               {/* 스크랩 */}
-              <button
-                type="button"
-                onClick={(e) => togglePostBookmark(e)}
-                className="flex items-center space-x-2 text-gray-600 hover:text-blue-500 transition-colors"
-                aria-pressed={postBookmarked}
-              >
-                {postBookmarked ? <FaBookmark className="text-blue-500" /> : <FaRegBookmark />}
-                <span>{postBookmarkCount}</span>
-              </button>
+               <button
+                 type="button"
+                 onClick={(e) => {
+                   e.preventDefault();
+                   e.stopPropagation();
+                   e.nativeEvent?.stopImmediatePropagation?.();
+                   togglePostBookmark(e);
+                 }}
+                 className="flex items-center space-x-2 text-gray-600 hover:text-blue-500 transition-colors"
+                 aria-pressed={postBookmarked}
+               >
+                 {postBookmarked ? <FaBookmark className="text-blue-500" /> : <FaRegBookmark />}
+                 <span>{postBookmarked ? (post.bookmarks ?? 0) + 1 : (post.bookmarks ?? 0)}</span>
+               </button>
               {/* 댓글 */}
               <div className="flex items-center space-x-2 text-gray-600">
                 <FaComment />

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react'
-import { FaHeart, FaRegHeart, FaComment, FaEye, FaStar } from 'react-icons/fa'
+import React, { useState } from 'react'
+import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark, FaComment, FaEye, FaStar } from 'react-icons/fa'
 import Header from '../components/header/Header'
 import { useParams } from 'react-router-dom'
 import { samplePosts } from '../components/postcontext'
@@ -16,25 +16,26 @@ function PostDetail() {
   const [feedbackContent, setFeedbackContent] = useState('')
   const [showAllFeedbacks, setShowAllFeedbacks] = useState(false)
   const [feedbackSort, setFeedbackSort] = useState('latest')
-  const [feedbackItems, setFeedbackItems] = useState([])
-  const [isFeedbackFormOpen, setIsFeedbackFormOpen] = useState(false)
 
-  useEffect(() => {
-    const nextItems = sampleFeedbacks
-      .filter(f => f.postId === post.id)
-      .map(f => ({ ...f, isLiked: Boolean(f.isLiked) }))
-    setFeedbackItems(nextItems)
-  }, [post.id])
+  const [postLiked, setPostLiked] = useState(Boolean(post.isLiked))
+  const [postBookmarked, setPostBookmarked] = useState(Boolean(post.isBookmarked))
+  const [postLikeCount, setPostLikeCount] = useState(post.likes ?? 0)
+  const [postBookmarkCount, setPostBookmarkCount] = useState(post.bookmarks ?? 0)
 
-  const toggleFeedbackLike = (feedbackId) => {
-    setFeedbackItems(items =>
-      items.map(item => {
-        if (item.id !== feedbackId) return item
-        const nextLiked = !item.isLiked
-        const nextLikes = item.likes + (nextLiked ? 1 : -1)
-        return { ...item, isLiked: nextLiked, likes: nextLikes }
-      })
-    )
+  const togglePostLike = () => {
+    setPostLiked(prev => {
+      const next = !prev
+      setPostLikeCount(c => c + (next ? 1 : -1))
+      return next
+    })
+  }
+
+  const togglePostBookmark = () => {
+    setPostBookmarked(prev => {
+      const next = !prev
+      setPostBookmarkCount(c => c + (next ? 1 : -1))
+      return next
+    })
   }
 
   const feedbackTypes = ['일반 피드백', '개선 제안', '버그 신고']
@@ -79,14 +80,32 @@ function PostDetail() {
           {/* 통계 */}
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-6 mb-0">
+              {/* 좋아요 */}
+              <button
+                type="button"
+                onClick={togglePostLike}
+                className="flex items-center space-x-2 text-gray-600 hover:text-red-500 transition-colors"
+                aria-pressed={postLiked}
+              >
+                {postLiked ? <FaHeart className="text-red-500" /> : <FaRegHeart />}
+                <span>{postLikeCount}</span>
+              </button>
+              {/* 스크랩 */}
+              <button
+                type="button"
+                onClick={togglePostBookmark}
+                className="flex items-center space-x-2 text-gray-600 hover:text-blue-500 transition-colors"
+                aria-pressed={postBookmarked}
+              >
+                {postBookmarked ? <FaBookmark className="text-blue-500" /> : <FaRegBookmark />}
+                <span>{postBookmarkCount}</span>
+              </button>
+              {/* 댓글 */}
               <div className="flex items-center space-x-2 text-gray-600">
-                <FaHeart className="text-red-500" />
-                <span>{post.likes}</span>
-              </div>
-              <div className="flex items-center space-x-2 text-gray-600">
-                <FaComment className="text-blue-500" />
+                <FaComment />
                 <span>{post.comments}</span>
               </div>
+              {/* 조회수 */}
               <div className="flex items-center space-x-2 text-gray-600">
                 <FaEye className="text-gray-500" />
                 <span>{post.views}</span>
@@ -130,79 +149,58 @@ function PostDetail() {
               {/* 피드백 작성 */}
               <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">피드백 작성</h3>
-                {!isFeedbackFormOpen ? (
-                  <button
-                    type="button"
-                    onClick={() => setIsFeedbackFormOpen(true)}
-                    className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors"
-                  >
-                    피드백 작성하기
-                  </button>
-                ) : (
-                  <>
-                    {/* 피드백 유형 */}
-                    <div className="mb-4">
-                      <label className="block text-sm font-medium text-gray-700 mb-2">피드백 유형</label>
-                      <div className="flex space-x-2">
-                        {feedbackTypes.map((type) => (
-                          <button
-                            key={type}
-                            onClick={() => setSelectedFeedbackType(type)}
-                            className={`px-3 py-1 text-sm rounded-md transition-colors ${
-                              selectedFeedbackType === type
-                                ? 'bg-green-600 text-white'
-                                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                            }`}
-                          >
-                            {type}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                    {/* 평점 */}
-                    <div className="mb-4">
-                      <label className="block text-sm font-medium text-gray-700 mb-2">평점</label>
-                      <div className="flex space-x-1">
-                        {[1, 2, 3, 4, 5].map((star) => (
-                          <button
-                            key={star}
-                            onClick={() => setRating(star)}
-                            className="text-2xl transition-colors"
-                          >
-                            <FaStar 
-                              className={star <= rating ? 'text-yellow-400' : 'text-gray-300'} 
-                            />
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                    {/* 피드백 내용 */}
-                    <div className="mb-4">
-                      <label className="block text-sm font-medium text-gray-700 mb-2">피드백 내용</label>
-                      <textarea
-                        value={feedbackContent}
-                        onChange={(e) => setFeedbackContent(e.target.value)}
-                        placeholder="새싹에 대한 피드백을 작성해주세요. 구체적이고 건설적인 피드백이 도움이 됩니다."
-                        rows="4"
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none resize-none"
-                      />
-                      <p className="text-sm text-gray-500 mt-1">{feedbackContent.length}/1000자</p>
-                    </div>
-                    {/* 제출/취소 */}
-                    <div className="flex gap-2">
-                      <button className="flex-1 bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors">
-                        피드백 제출
-                      </button>
+                {/* 피드백 유형 */}
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 유형</label>
+                  <div className="flex space-x-2">
+                    {feedbackTypes.map((type) => (
                       <button
-                        type="button"
-                        onClick={() => setIsFeedbackFormOpen(false)}
-                        className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                        key={type}
+                        onClick={() => setSelectedFeedbackType(type)}
+                        className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                          selectedFeedbackType === type
+                            ? 'bg-green-600 text-white'
+                            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                        }`}
                       >
-                        취소
+                        {type}
                       </button>
-                    </div>
-                  </>
-                )}
+                    ))}
+                  </div>
+                </div>
+                {/* 평점 */}
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">평점</label>
+                  <div className="flex space-x-1">
+                    {[1, 2, 3, 4, 5].map((star) => (
+                      <button
+                        key={star}
+                        onClick={() => setRating(star)}
+                        className="text-2xl transition-colors"
+                      >
+                        <FaStar 
+                          className={star <= rating ? 'text-yellow-400' : 'text-gray-300'} 
+                        />
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                {/* 피드백 내용 */}
+                <div className="mb-4">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">피드백 내용</label>
+                  <textarea
+                    value={feedbackContent}
+                    onChange={(e) => setFeedbackContent(e.target.value)}
+                    placeholder="새싹에 대한 피드백을 작성해주세요. 구체적이고 건설적인 피드백이 도움이 됩니다."
+                    rows="4"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent outline-none resize-none"
+                  />
+                  <p className="text-sm text-gray-500 mt-1">{feedbackContent.length}/1000자</p>
+                </div>
+                {/* 제출 버튼 */}
+                <button className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors">
+                  피드백 제출
+                </button>
               </div>
 
           {/* 기존 피드백 댓글 */}
@@ -231,7 +229,7 @@ function PostDetail() {
 
             <div className="space-y-4">
               {(() => {
-                const all = feedbackItems
+                const all = sampleFeedbacks.filter(f => f.postId === post.id)
                 const INITIAL_COUNT = 4
                 const list = showAllFeedbacks ? all : all.slice(0, INITIAL_COUNT)
                 return list.map((fb) => (
@@ -255,20 +253,13 @@ function PostDetail() {
                         {fb.content}
                       </p>
                       <div className="flex items-center space-x-4 text-sm text-gray-500">
-                        {/* 좋아요 */}
-                        <button
-                          type="button"
-                          onClick={() => toggleFeedbackLike(fb.id)}
-                          className="flex items-center space-x-1 text-gray-600 hover:text-red-500 transition-colors"
-                          aria-pressed={fb.isLiked}
-                        >
-                          {fb.isLiked ? <FaHeart className="text-red-500" /> : <FaRegHeart />}
-                          <span className="text-sm font-medium">{fb.likes}</span>
-                        </button>
-                        {/* 댓글 */}
-                        <div className="flex items-center space-x-1 text-gray-600">
-                          <FaComment />
-                          <span className="text-sm font-medium">{fb.comments}</span>
+                        <div className="flex items-center space-x-1">
+                          <FaHeart className="text-red-500" />
+                          <span>{fb.likes}</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                          <FaComment className="text-gray-500" />
+                          <span>{fb.comments}</span>
                         </div>
                         <div className="flex items-center space-x-1">
                           <FaEye className="text-gray-500" />
@@ -281,7 +272,7 @@ function PostDetail() {
               })()}
             </div>
             {(() => {
-              const total = feedbackItems.length
+              const total = sampleFeedbacks.filter(f => f.postId === post.id).length
               const INITIAL_COUNT = 4
               if (showAllFeedbacks || total <= INITIAL_COUNT) return null
               return (

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -3,6 +3,7 @@ import { FaHeart, FaComment, FaEye, FaStar } from 'react-icons/fa'
 import Header from '../components/header/Header'
 import { useParams } from 'react-router-dom'
 import { samplePosts } from '../components/postcontext'
+import { sampleFeedbacks } from '../components/feedbackContext'
 
 function PostDetail() {
   const { postId } = useParams()
@@ -161,47 +162,48 @@ function PostDetail() {
                 </button>
               </div>
 
-              {/* 기존 피드백 댓글 */}
+          {/* 기존 피드백 댓글 */}
               <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">기존 피드백</h3>
-                <div className="space-y-4">
-                  {[1, 2].map((comment) => (
-                    <div key={comment} className="border-b border-gray-200 pb-4 last:border-b-0">
-                      <div className="flex items-center mb-2">
-                        <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-semibold mr-2">
-                          농
-                        </div>
-                        <div>
-                          <p className="font-semibold text-gray-900 text-sm">농담곰</p>
-                          <p className="text-xs text-gray-500">3시간 전</p>
-                        </div>
+            <div className="space-y-4">
+              {sampleFeedbacks
+                .filter(f => f.postId === post.id)
+                .map((fb) => (
+                  <div key={fb.id} className="border-b border-gray-200 pb-4 last:border-b-0 last:pb-0">
+                    <div className="flex items-center mb-2">
+                      <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-semibold mr-2">
+                        {fb.avatarInitial}
                       </div>
-                      <div className="flex mb-2">
-                        {[1, 2, 3, 4, 5].map((star) => (
-                          <FaStar key={star} className="text-yellow-400 text-sm" />
-                        ))}
-                      </div>
-                      <p className="text-gray-700 text-sm leading-relaxed mb-3">
-                        성능 최적화 측면에서 몇 가지 개선점이 있습니다. filteredTodos 계산을 useMemo로 감싸고, 
-                        이벤트 핸들러들을 useCallback으로 최적화하면 리렌더링을 줄일 수 있을 것 같습니다.
-                      </p>
-                      <div className="flex items-center space-x-4 text-sm text-gray-500">
-                        <div className="flex items-center space-x-1">
-                          <FaHeart className="text-red-500" />
-                          <span>23</span>
-                        </div>
-                        <div className="flex items-center space-x-1">
-                          <FaComment className="text-blue-500" />
-                          <span>13</span>
-                        </div>
-                        <div className="flex items-center space-x-1">
-                          <FaEye className="text-gray-500" />
-                          <span>237</span>
-                        </div>
+                      <div>
+                        <p className="font-semibold text-gray-900 text-sm">{fb.author}</p>
+                        <p className="text-xs text-gray-500">{fb.timeAgo}</p>
                       </div>
                     </div>
-                  ))}
-                </div>
+                    <div className="flex mb-2">
+                      {[1, 2, 3, 4, 5].map((star) => (
+                        <FaStar key={star} className={`text-sm ${star <= fb.rating ? 'text-yellow-400' : 'text-gray-300'}`} />
+                      ))}
+                    </div>
+                    <p className="text-gray-700 text-sm leading-relaxed mb-3">
+                      {fb.content}
+                    </p>
+                    <div className="flex items-center space-x-4 text-sm text-gray-500">
+                      <div className="flex items-center space-x-1">
+                        <FaHeart className="text-red-500" />
+                        <span>{fb.likes}</span>
+                      </div>
+                      <div className="flex items-center space-x-1">
+                        <FaComment className="text-blue-500" />
+                        <span>{fb.comments}</span>
+                      </div>
+                      <div className="flex items-center space-x-1">
+                        <FaEye className="text-gray-500" />
+                        <span>{fb.views}</span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+            </div>
               </div>
             </div>
           </div>

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react'
 import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark, FaComment, FaEye, FaStar } from 'react-icons/fa'
 import Header from '../components/header/Header'
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import { samplePosts } from '../components/postcontext'
 import { sampleFeedbacks } from '../components/feedbackContext'
 
 function PostDetail() {
   const { postId } = useParams()
+  const navigate = useNavigate()
   const idNum = Number(postId)
   const post = (Number.isNaN(idNum)
     ? samplePosts[0]
@@ -292,7 +293,10 @@ function PostDetail() {
                 const list = showAllFeedbacks ? all : all.slice(0, INITIAL_COUNT)
                 return list.map((fb) => (
                   <div key={fb.id} className="border-b border-gray-200 pb-4 last:border-b-0 last:pb-0">
-                    <div className="rounded-md p-3 transition-all hover:bg-gray-50 hover:ring-1 hover:ring-gray-200">
+                    <div
+                      className="rounded-md p-3 transition-all hover:bg-gray-50 hover:ring-1 hover:ring-gray-200 cursor-pointer"
+                      onClick={() => navigate(`/posts/${post.id}/${fb.id}`)}
+                    >
                       <div className="flex items-center mb-2">
                         <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-semibold mr-2">
                           {fb.avatarInitial}

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { FaHeart, FaRegHeart, FaBookmark, FaRegBookmark, FaComment, FaEye, FaStar } from 'react-icons/fa'
 import Header from '../components/header/Header'
 import { useParams } from 'react-router-dom'
@@ -35,6 +35,27 @@ function PostDetail() {
       const next = !prev
       setPostBookmarkCount(c => c + (next ? 1 : -1))
       return next
+    })
+  }
+
+  const [feedbackLikeState, setFeedbackLikeState] = useState({})
+
+  useEffect(() => {
+    const init = {}
+    sampleFeedbacks
+      .filter(f => f.postId === post.id)
+      .forEach(f => {
+        init[f.id] = { liked: false, count: f.likes ?? 0 }
+      })
+    setFeedbackLikeState(init)
+  }, [post.id])
+
+  const toggleFeedbackLike = (feedbackId) => {
+    setFeedbackLikeState(prev => {
+      const curr = prev[feedbackId] || { liked: false, count: 0 }
+      const nextLiked = !curr.liked
+      const nextCount = Math.max(0, curr.count + (nextLiked ? 1 : -1))
+      return { ...prev, [feedbackId]: { liked: nextLiked, count: nextCount } }
     })
   }
 
@@ -253,10 +274,19 @@ function PostDetail() {
                         {fb.content}
                       </p>
                       <div className="flex items-center space-x-4 text-sm text-gray-500">
-                        <div className="flex items-center space-x-1">
-                          <FaHeart className="text-red-500" />
-                          <span>{fb.likes}</span>
-                        </div>
+                        <button
+                          type="button"
+                          onClick={() => toggleFeedbackLike(fb.id)}
+                          className="flex items-center space-x-1 text-gray-600 hover:text-red-500 transition-colors"
+                          aria-pressed={feedbackLikeState[fb.id]?.liked}
+                        >
+                          {feedbackLikeState[fb.id]?.liked ? (
+                            <FaHeart className="text-red-500" />
+                          ) : (
+                            <FaRegHeart />
+                          )}
+                          <span className="text-sm font-medium">{feedbackLikeState[fb.id]?.count ?? fb.likes}</span>
+                        </button>
                         <div className="flex items-center space-x-1">
                           <FaComment className="text-gray-500" />
                           <span>{fb.comments}</span>

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -17,6 +17,7 @@ function PostDetail() {
   const [showAllFeedbacks, setShowAllFeedbacks] = useState(false)
   const [feedbackSort, setFeedbackSort] = useState('latest')
   const [isFeedbackFormOpen, setIsFeedbackFormOpen] = useState(false)
+  const [isAIFeedbackOpen, setIsAIFeedbackOpen] = useState(false)
 
   const [postLiked, setPostLiked] = useState(Boolean(post.isLiked))
   const [postBookmarked, setPostBookmarked] = useState(Boolean(post.isBookmarked))
@@ -134,7 +135,13 @@ function PostDetail() {
               </div>
             </div>
             <div>
-              <button className='bg-green-600 text-white px-4 py-2 rounded-md'>AI 피드백</button>
+              <button
+                type="button"
+                onClick={() => setIsAIFeedbackOpen((v) => !v)}
+                className='bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700 transition-colors'
+              >
+                AI 피드백
+              </button>
             </div>
           </div>
         </div>
@@ -144,6 +151,14 @@ function PostDetail() {
           {/*코드 에디터 */}
           <div className="lg:col-span-2">
             <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"> 코드에디터 </div>
+            {isAIFeedbackOpen && (
+              <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mt-4">
+                <h3 className="text-lg font-semibold text-gray-800 mb-3">AI 피드백</h3>
+                <div className="text-gray-700 leading-relaxed whitespace-pre-line">
+                  {`코드 전반에서 변수 네이밍이 일관적이며 가독성이 좋습니다.\n\n개선 제안:\n- 불변성 보장을 위해 배열/객체 업데이트 시 전개 연산자를 사용하세요.\n- 연산이 잦은 파생 값은 useMemo로 감싸면 리렌더링 비용을 줄일 수 있습니다.\n- 이벤트 핸들러는 useCallback으로 메모이제이션하면 자식 컴포넌트 재렌더를 방지합니다.`}
+                </div>
+              </div>
+            )}
           </div>
 
           {/* 피드백 요청 + 작성 + 기존 피드백 */}

--- a/src/pages/PostDetail.jsx
+++ b/src/pages/PostDetail.jsx
@@ -14,6 +14,8 @@ function PostDetail() {
   const [selectedFeedbackType, setSelectedFeedbackType] = useState('일반 피드백')
   const [rating, setRating] = useState(5)
   const [feedbackContent, setFeedbackContent] = useState('')
+  const [showAllFeedbacks, setShowAllFeedbacks] = useState(false)
+  const [feedbackSort, setFeedbackSort] = useState('latest')
 
   const feedbackTypes = ['일반 피드백', '개선 제안', '버그 신고']
 
@@ -165,45 +167,87 @@ function PostDetail() {
           {/* 기존 피드백 댓글 */}
               <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
                 <h3 className="text-lg font-semibold text-gray-800 mb-4">기존 피드백</h3>
+            {/* 정렬 옵션 */}
+            <div className="mb-3 flex items-center gap-2">
+              {[
+                { key: 'latest', label: '최신순' },
+                { key: 'recommended', label: '추천순' },
+                { key: 'detail', label: '상세 피드백 라인 순' },
+              ].map((opt) => (
+                <button
+                  key={opt.key}
+                  onClick={() => setFeedbackSort(opt.key)}
+                  className={`px-3 py-1 rounded border text-sm ${
+                    feedbackSort === opt.key
+                      ? 'bg-green-600 text-white border-green-600'
+                      : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+
             <div className="space-y-4">
-              {sampleFeedbacks
-                .filter(f => f.postId === post.id)
-                .map((fb) => (
+              {(() => {
+                const all = sampleFeedbacks.filter(f => f.postId === post.id)
+                const INITIAL_COUNT = 4
+                const list = showAllFeedbacks ? all : all.slice(0, INITIAL_COUNT)
+                return list.map((fb) => (
                   <div key={fb.id} className="border-b border-gray-200 pb-4 last:border-b-0 last:pb-0">
-                    <div className="flex items-center mb-2">
-                      <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-semibold mr-2">
-                        {fb.avatarInitial}
+                    <div className="rounded-md p-3 transition-all hover:bg-gray-50 hover:ring-1 hover:ring-gray-200">
+                      <div className="flex items-center mb-2">
+                        <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center text-white text-sm font-semibold mr-2">
+                          {fb.avatarInitial}
+                        </div>
+                        <div>
+                          <p className="font-semibold text-gray-900 text-sm">{fb.author}</p>
+                          <p className="text-xs text-gray-500">{fb.timeAgo}</p>
+                        </div>
                       </div>
-                      <div>
-                        <p className="font-semibold text-gray-900 text-sm">{fb.author}</p>
-                        <p className="text-xs text-gray-500">{fb.timeAgo}</p>
+                      <div className="flex mb-2">
+                        {[1, 2, 3, 4, 5].map((star) => (
+                          <FaStar key={star} className={`text-sm ${star <= fb.rating ? 'text-yellow-400' : 'text-gray-300'}`} />
+                        ))}
                       </div>
-                    </div>
-                    <div className="flex mb-2">
-                      {[1, 2, 3, 4, 5].map((star) => (
-                        <FaStar key={star} className={`text-sm ${star <= fb.rating ? 'text-yellow-400' : 'text-gray-300'}`} />
-                      ))}
-                    </div>
-                    <p className="text-gray-700 text-sm leading-relaxed mb-3">
-                      {fb.content}
-                    </p>
-                    <div className="flex items-center space-x-4 text-sm text-gray-500">
-                      <div className="flex items-center space-x-1">
-                        <FaHeart className="text-red-500" />
-                        <span>{fb.likes}</span>
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <FaComment className="text-blue-500" />
-                        <span>{fb.comments}</span>
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <FaEye className="text-gray-500" />
-                        <span>{fb.views}</span>
+                      <p className="text-gray-700 text-sm leading-relaxed mb-3">
+                        {fb.content}
+                      </p>
+                      <div className="flex items-center space-x-4 text-sm text-gray-500">
+                        <div className="flex items-center space-x-1">
+                          <FaHeart className="text-red-500" />
+                          <span>{fb.likes}</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                          <FaComment className="text-blue-500" />
+                          <span>{fb.comments}</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                          <FaEye className="text-gray-500" />
+                          <span>{fb.views}</span>
+                        </div>
                       </div>
                     </div>
                   </div>
-                ))}
+                ))
+              })()}
             </div>
+            {(() => {
+              const total = sampleFeedbacks.filter(f => f.postId === post.id).length
+              const INITIAL_COUNT = 4
+              if (showAllFeedbacks || total <= INITIAL_COUNT) return null
+              return (
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    onClick={() => setShowAllFeedbacks(true)}
+                    className="w-full py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50"
+                  >
+                    더보기
+                  </button>
+                </div>
+              )
+            })()}
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 게시물 상세 페이지 UI 구현
## 🔧 주요 변경 내용
<!-- 주요 변경사항들을 나열해주세요 -->
- `피드백` 클릭 시 -> 피드백 상세 페이지로 이동
- `피드백 작성하기` 버튼을 통해 피드백 작성 폼 열기
- 각 버튼 클릭시 동작(기능구현은 x)
## 📸 스크린샷 (UI 변경이 있는 경우)

<img width="1872" height="1973" alt="localhost_3000_posts_1" src="https://github.com/user-attachments/assets/22f1ad5b-ae6e-4cb5-8652-78f035aa7eb1" />

<img width="1872" height="2692" alt="localhost_3000_posts_1 (1)" src="https://github.com/user-attachments/assets/eb82b9f2-54b7-4539-9535-d6f515a35588" />


## 📋 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 적어주세요 -->
코드에디터는 추후 component에 추가하고 업로드, 상세이지 등 한번에 합칠 예정입니다!
## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
#5 