### PR TITLE
feat: 마이페이지 UI 구현

### DIFF
--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -1,0 +1,159 @@
+import React, { useState } from "react";
+import {
+  FaHeart,
+  FaRegHeart,
+  FaBookmark,
+  FaRegBookmark,
+  FaComment,
+  FaEye,
+} from "react-icons/fa";
+import { IoMdTime } from "react-icons/io";
+
+function PostCard({
+  avatar,
+  author,
+  timeAgo,
+  title,
+  content,
+  tags = [],
+  likes = 0,
+  comments = 0,
+  views = 0,
+  isLiked = false,
+  isBookmarked = false,
+  onClick,
+  onLike,
+  onBookmark,
+}) {
+  // 설명 110자 초과 시 '...' 표시
+  const truncatedContent =
+    typeof content === "string"
+      ? content.length > 110
+        ? content.slice(0, 110) + "..."
+        : content
+      : "";
+
+  // 토글 상태
+  const [liked, setLiked] = useState(isLiked);
+  const [bookmarked, setBookmarked] = useState(isBookmarked);
+  const [likeCount, setLikeCount] = useState(likes);
+
+  const handleToggleLike = (e) => {
+    e.stopPropagation();
+    setLiked((prev) => {
+      const next = !prev;
+      setLikeCount((c) => (next ? c + 1 : Math.max(0, c - 1)));
+      onLike && onLike(next);
+      return next;
+    });
+  };
+
+  const handleToggleBookmark = (e) => {
+    e.stopPropagation();
+    setBookmarked((prev) => {
+      const next = !prev;
+      onBookmark && onBookmark(next);
+      return next;
+    });
+  };
+
+  return (
+    <div
+      className="h-full flex flex-col bg-white border border-gray-200 rounded-xl p-5 transition-shadow cursor-pointer"
+      onClick={onClick}
+    >
+      {/* 상단: 작성자/시간 */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <div className="w-[40px] h-[40px] rounded-full bg-green-100 border border-gray-300 flex items-center justify-center overflow-hidden">
+            <span className="text-xl">{avatar}</span>
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-semibold text-[14px]">{author}</span>
+            </div>
+            <div className="text-[10px] text-gray-500">
+              <IoMdTime className="inline-block -mt-0.5 mr-1" />
+              {timeAgo}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 본문 */}
+      <div className="flex-1">
+        {/* 제목 */}
+        <h2 className="text-[16px] font-semibold text-[#343434] leading-snug line-clamp-1 min-h-[24px]">
+          {title}
+        </h2>
+
+        {/* 설명 */}
+        <p className="mt-1 text-[#8F8F8F] text-[12px] leading-relaxed min-h-[36px]">
+          {truncatedContent}
+        </p>
+
+        {/* 태그 */}
+        <div className="flex flex-wrap gap-2 mt-3 mb-2 mr-2 min-h-[28px]">
+          {tags.map((tag, i) => (
+            <span
+              key={`${tag}-${i}`}
+              className={[
+                "inline-flex items-center justify-center",
+                "h-7 px-3 rounded-full",
+                "text-[10px] font-medium leading-none",
+                i === 0
+                  ? "bg-[#E9FFEA] text-[#00B834] border border-[#C8F4CE]"
+                  : "bg-[#00B834] text-white",
+              ].join(" ")}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* 하단 */}
+      <div className="pt-3 mt-auto border-t border-gray-100 flex items-center justify-between">
+        <div className="flex items-center gap-6 text-[#4D4D4D]">
+          {/* 좋아요 */}
+          <button
+            className="flex items-center gap-1 hover:opacity-80 transition"
+            onClick={handleToggleLike}
+            type="button"
+            aria-label="좋아요"
+          >
+            {liked ? <FaHeart className="text-red-500" /> : <FaRegHeart />}
+            <span className="text-[10px] font-medium">{likeCount}</span>
+          </button>
+
+          {/* 스크랩 */}
+          <button
+            className={`flex items-center gap-1 transition ${
+              bookmarked ? "text-blue-500" : "hover:text-blue-500"
+            }`}
+            onClick={handleToggleBookmark}
+            type="button"
+            aria-label="스크랩"
+          >
+            {bookmarked ? <FaBookmark /> : <FaRegBookmark />}
+            <span className="text-[10px] font-medium">스크랩</span>
+          </button>
+
+          {/* 피드백수 */}
+          <div className="flex items-center gap-1">
+            <FaComment />
+            <span className="text-[10px] font-medium">{comments}</span>
+          </div>
+
+          {/* 조회수 */}
+          <div className="flex items-center gap-1">
+            <FaEye />
+            <span className="text-[10px]">{views}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PostCard;

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -5,8 +5,15 @@ import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
 import { VscFeedback } from "react-icons/vsc";
 import samplePosts from "../components/postcontext.jsx";
 import PostCard from "../components/PostCard.jsx";
+import { useNavigate } from "react-router-dom";
 
 function MyPaged() {
+  const navigate = useNavigate();
+
+  const handlePostClick = (postId) => {
+    navigate(`/posts/${postId}`);
+  };
+
   const profile = {
     name: "Chiikawa",
     avatar: profileImg,
@@ -186,6 +193,7 @@ function MyPaged() {
                     {...p}
                     badge="내 게시글"
                     rightPill={null}
+                    onClick={() => handlePostClick(p.id)}
                   />
                 ))}
               </div>
@@ -228,6 +236,7 @@ function MyPaged() {
                     {...p}
                     badge="내 피드백"
                     rightPill={null}
+                    onClick={() => handlePostClick(p.id)}
                   />
                 ))}
               </div>

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import Header from "../components/header/Header";
 import profileImg from "../assets/profile.png";
 import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
 import { VscFeedback } from "react-icons/vsc";
+import samplePosts from "../components/postcontext.jsx";
+import PostCard from "../components/PostCard.jsx";
 
 function MyPaged() {
   const profile = {
@@ -15,7 +17,7 @@ function MyPaged() {
     gradeLabel: "등급",
   };
 
-  // 등급 도넛
+  // === Donut ===
   const GradeDonut = ({ percent = 50, label = "등급" }) => {
     const size = 120;
     const stroke = 12;
@@ -54,12 +56,39 @@ function MyPaged() {
     );
   };
 
+  const myPostsAll = samplePosts; // 임시 데이터 가져옴
+  const myFeedbackAll = samplePosts;
+
+  const INITIAL_COUNT = 4; // 기본 노출 게시글은 4개
+  const [activeTab, setActiveTab] = useState("posts"); // 'posts' | 'feedback'
+  const [myPostsCount, setMyPostsCount] = useState(INITIAL_COUNT);
+  const [myFeedbackCount, setMyFeedbackCount] = useState(INITIAL_COUNT);
+
+  // 접기 버튼 클릭 시 스크롤 복귀
+  const postsRef = useRef(null);
+  const feedbackRef = useRef(null);
+
+  const isPostsExpanded = myPostsCount >= myPostsAll.length;
+  const isFeedbackExpanded = myFeedbackCount >= myFeedbackAll.length;
+
+  const expandPosts = () => setMyPostsCount(myPostsAll.length);
+  const collapsePosts = () => {
+    setMyPostsCount(INITIAL_COUNT);
+    postsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const expandFeedback = () => setMyFeedbackCount(myFeedbackAll.length);
+  const collapseFeedback = () => {
+    setMyFeedbackCount(INITIAL_COUNT);
+    feedbackRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   return (
     <div className="min-h-screen bg-[#F5F7FA]">
       <Header />
       <div className="mx-auto max-w-[1100px] px-4 py-8">
-        <div className="rounded-[10px] border border-gray-200 bg-white p-5 shadow-sm">
-          <div className="flex items-center gap-5 px-20">
+        <div className="rounded-[10px] border border-gray-200 bg-white px-10 py-5 shadow-sm">
+          <div className="flex items-center gap-5 px-20 mb-10">
             {/* 프로필 */}
             <div className="h-full w-[132px] overflow-hidden rounded-[10px]">
               <img
@@ -71,10 +100,9 @@ function MyPaged() {
 
             {/* 가운데 박스 */}
             <div
-              className="flex-1 w-[825px] h- rounded-[10px] border border-[#ACACAC] bg-white
-                            pl-6 pr-3 py-4 flex items-center justify-between box-border overflow-hidden"
+              className="flex-1 w-[825px] rounded-[10px] border border-[#ACACAC] bg-white
+                          pl-6 pr-3 py-4 flex items-center justify-between box-border overflow-hidden"
             >
-              {/* 이름/지표 */}
               <div className="flex-1 min-w-0">
                 <h2 className="text-[22px] font-semibold mb-2">
                   {profile.name}
@@ -114,6 +142,118 @@ function MyPaged() {
               </div>
             </div>
           </div>
+
+          {/* 탭 */}
+          <div className="flex gap-2 mb-5 px-1">
+            <button
+              onClick={() => setActiveTab("posts")}
+              className={`px-3 py-1.5 rounded-full text-sm border transition
+                ${
+                  activeTab === "posts"
+                    ? "bg-[#00B834] text-white border-[#00B834]"
+                    : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+                }`}
+            >
+              내 게시글 ({myPostsAll.length})
+            </button>
+
+            <button
+              onClick={() => setActiveTab("feedback")}
+              className={`px-3 py-1.5 rounded-full text-sm border transition
+                ${
+                  activeTab === "feedback"
+                    ? "bg-[#00B834] text-white border-[#00B834]"
+                    : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+                }`}
+            >
+              내 피드백 ({myFeedbackAll.length})
+            </button>
+          </div>
+
+          {/* 내 게시글 영역 */}
+          {activeTab === "posts" && (
+            <section ref={postsRef} className="mb-10">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-[16px] font-semibold ml-1">
+                  내가 올린 게시글
+                </h2>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {myPostsAll.slice(0, myPostsCount).map((p) => (
+                  <PostCard
+                    key={`mypost-${p.id}`}
+                    {...p}
+                    badge="내 게시글"
+                    rightPill={null}
+                  />
+                ))}
+              </div>
+
+              {/* 더보기/접기 버튼 */}
+              <div className="mt-6 flex items-center justify-center gap-2">
+                {myPostsAll.length > INITIAL_COUNT && !isPostsExpanded && (
+                  <button
+                    onClick={expandPosts}
+                    className="px-4 py-2 text-sm rounded-md border border-[#00B834] text-[#00B834] hover:bg-[#00B834]/5"
+                  >
+                    더보기
+                  </button>
+                )}
+                {myPostsAll.length > INITIAL_COUNT && isPostsExpanded && (
+                  <button
+                    onClick={collapsePosts}
+                    className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                  >
+                    접기
+                  </button>
+                )}
+              </div>
+            </section>
+          )}
+
+          {/* 내 피드백 영역 */}
+          {activeTab === "feedback" && (
+            <section ref={feedbackRef} className="mb-2">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-[16px] font-semibold ml-1">
+                  내가 등록한 피드백
+                </h2>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {myFeedbackAll.slice(0, myFeedbackCount).map((p) => (
+                  <PostCard
+                    key={`myfb-${p.id}`}
+                    {...p}
+                    badge="내 피드백"
+                    rightPill={null}
+                  />
+                ))}
+              </div>
+
+              {/* 더보기/접기 버튼 */}
+              <div className="mt-6 flex items-center justify-center gap-2">
+                {myFeedbackAll.length > INITIAL_COUNT &&
+                  !isFeedbackExpanded && (
+                    <button
+                      onClick={expandFeedback}
+                      className="px-4 py-2 text-sm rounded-md border border-[#00B834] text-[#00B834] hover:bg-[#00B834]/5"
+                    >
+                      더보기
+                    </button>
+                  )}
+                {myFeedbackAll.length > INITIAL_COUNT && isFeedbackExpanded && (
+                  <button
+                    onClick={collapseFeedback}
+                    className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                  >
+                    접기
+                  </button>
+                )}
+              </div>
+            </section>
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -1,14 +1,135 @@
-import React from 'react'
+import React from "react";
+import Header from "../components/header/Header";
+import profileImg from "../assets/profile.png";
+import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
+import { VscFeedback } from "react-icons/vsc";
 
 function MyPaged() {
+  const profile = {
+    name: "Chiikawa",
+    avatar: profileImg,
+    points: 4300,
+    selectRate: 50,
+    postCount: 3,
+    feedbackCount: 5,
+    gradeLabel: "등급",
+  };
+
+  // 등급 도넛
+  const GradeDonut = ({ percent = 50, label = "등급" }) => {
+    const size = 120;
+    const stroke = 12;
+    const r = (size - stroke) / 2;
+    const c = 2 * Math.PI * r;
+    const dash = (percent / 100) * c;
+
+    return (
+      <div className="relative">
+        <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            stroke="#E5E7EB"
+            strokeWidth={stroke}
+            fill="none"
+          />
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={r}
+            stroke="#10B981"
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            fill="none"
+            strokeDasharray={`${dash} ${c - dash}`}
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-[13px] font-semibold text-gray-800">
+            {label}
+          </span>
+        </div>
+      </div>
+    );
+  };
+
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-semibold">My Paged</h1>
-      <p>마이페이지</p>
+    <div className="min-h-screen bg-[#F5F7FA]">
+      <Header />
+      <div className="mx-auto max-w-[1100px] px-4 py-8">
+        <div className="rounded-[10px] border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center gap-5 px-20">
+            {/* 프로필 */}
+            <div className="h-full w-[132px] overflow-hidden rounded-[10px]">
+              <img
+                src={profile.avatar}
+                alt={`${profile.name} 프로필`}
+                className="h-full w-full object-cover"
+              />
+            </div>
+
+            {/* 가운데 박스 */}
+            <div
+              className="flex-1 w-[825px] h- rounded-[10px] border border-[#ACACAC] bg-white
+                            pl-6 pr-3 py-4 flex items-center justify-between box-border overflow-hidden"
+            >
+              {/* 이름/지표 */}
+              <div className="flex-1 min-w-0">
+                <h2 className="text-[22px] font-semibold mb-2">
+                  {profile.name}
+                </h2>
+                <ul className="space-y-2 text-[14px]">
+                  <Row
+                    icon={<TbCoin className="text-[#4D4D4D]" size={18} />}
+                    label="누적포인트"
+                    value={profile.points.toLocaleString()}
+                  />
+                  <Row
+                    icon={
+                      <TbMessage2Check className="text-[#4D4D4D]" size={18} />
+                    }
+                    label="피드백 채택률"
+                    value={`${profile.selectRate}%`}
+                  />
+                  <Row
+                    icon={<TbPencil className="text-[#4D4D4D]" size={18} />}
+                    label="등록한 게시물 수"
+                    value={profile.postCount}
+                  />
+                  <Row
+                    icon={<VscFeedback className="text-[#4D4D4D]" size={18} />}
+                    label="등록한 피드백 수"
+                    value={profile.feedbackCount}
+                  />
+                </ul>
+              </div>
+
+              {/* 등급 */}
+              <div className="shrink-0 ml-16 mr-5">
+                <GradeDonut
+                  percent={profile.selectRate}
+                  label={profile.gradeLabel}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  )
+  );
 }
 
-export default MyPaged
+function Row({ icon, label, value }) {
+  return (
+    <li className="flex items-center justify-between">
+      <div className="flex items-center gap-2 text-gray-800">
+        <span className="shrink-0">{icon}</span>
+        <span className="font-medium">{label}</span>
+      </div>
+      <span className="font-semibold text-gray-900">{value}</span>
+    </li>
+  );
+}
 
-
+export default MyPaged;


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 마이페이지 UI 구현
## 🔧 주요 변경 내용
<!-- 주요 변경사항들을 나열해주세요 -->
- 상단 프로필 영역 구현 - 프로필 이미지, 아이디, 지표, 등급
- `내 게시글` / `내 피드백` 탭 분리
   -> 기존 디자인했던 UI에서는 탭으로 분리하지 않고 위 아래 영역으로 나눴는데 그 상태에서는 게시글이 4개가 넘는 경우 문제 
   -> 탭으로 분리하고, 4개가 넘는 경우 `더보기` 버튼을 눌러 카드 목록을 펼치고, `접기` 버튼을 눌러 다시 돌아올 수 있게 구현  
- `PostCard` 컴포넌트 구현 - 게시글 카드 컴포넌트 -> 메인페이지에서 재사용 가능(/components/PostCard.jsx)
- 게시글 카드 클릭 시 해당 게시글 상세 페이지로 이동

## 📸 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1900" height="822" alt="image" src="https://github.com/user-attachments/assets/4c445d85-9a46-4c1e-a276-a7af85fc2b1d" />

- 더보기 버튼 클릭 시
<img width="1883" height="916" alt="image" src="https://github.com/user-attachments/assets/1871c7f4-953d-4cde-996f-99039beedd55" />

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크해주세요 -->
close #11 