### PR TITLE
feat: 마이페이지 API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,16 @@
-import React from 'react'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
-import Landing from './pages/Landing.jsx'
-import SignIn from './pages/SignIn.jsx'
-import SignUp from './pages/SignUp.jsx'
-import Main from './pages/Main.jsx'
-import Posts from './pages/Posts.jsx'
-import PostDetail from './pages/PostDetail.jsx'
-import FeedbackDetail from './pages/FeedbackDetail.jsx'
-import Upload from './pages/Upload.jsx'
-import LeaderBoard from './pages/LeaderBoard.jsx'
-import MyPaged from './pages/MyPaged.jsx'
-import NotFound from './pages/NotFound.jsx'
+import React from "react";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import Landing from "./pages/Landing.jsx";
+import SignIn from "./pages/SignIn.jsx";
+import SignUp from "./pages/SignUp.jsx";
+import Main from "./pages/Main.jsx";
+import Posts from "./pages/Posts.jsx";
+import PostDetail from "./pages/PostDetail.jsx";
+import FeedbackDetail from "./pages/FeedbackDetail.jsx";
+import Upload from "./pages/Upload.jsx";
+import LeaderBoard from "./pages/LeaderBoard.jsx";
+import MyPaged from "./pages/MyPaged.jsx";
+import NotFound from "./pages/NotFound.jsx";
 
 function App() {
   const isAuthed = localStorage.getItem("accessToken") ? true : false;
@@ -20,15 +20,14 @@ function App() {
       <Routes>
         {/* 리디렉션 */}
         <Route path="/" element={<Navigate to="/landing" replace />} />
-        
-
-        <Route path="/" element={<Navigate to={isAuthed ? '/main' : '/landing'} replace />} /> 
-
+        <Route
+          path="/"
+          element={<Navigate to={isAuthed ? "/main" : "/landing"} replace />}
+        />
         {/* 비로그인 시 */}
         <Route path="/landing" element={<Landing />} />
         <Route path="/sign-in" element={<SignIn />} />
         <Route path="/sign-up" element={<SignUp />} />
-
         {/* 로그인 시 (비로그인도 접근 가능) */}
         <Route path="/main" element={<Main />} />
         <Route path="/posts" element={<Posts />} />
@@ -39,13 +38,15 @@ function App() {
           element={isAuthed ? <Upload /> : <Navigate to="/sign-in" replace />}
         />
         <Route path="/leader-board" element={<LeaderBoard />} />
+        {/* 본인 프로필 */}
         <Route path="/my-paged" element={<MyPaged />} />
-
+        {/* 타인 프로필  */}
+        <Route path="/my-paged/:userId" element={<MyPaged />} />
         {/* 404 */}
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const api = axios.create({
   baseURL: "/",
-  withCredentials: false,
+  withCredentials: true,
 });
 
 // JWT 토큰 자동 추가

--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -67,3 +67,30 @@ export const deleteMyAccount = () => {
 export const deleteUserAsAdmin = (userId) => {
   return api.delete(`/api/user/${userId}/admin`);
 };
+
+export const updateProfilePicture = async (file) => {
+  const formData = new FormData();
+  formData.append("file", file);
+  try {
+    const response = await api.put("/api/user/profile-picture", formData, {});
+    return response.data;
+  } catch (error) {
+    console.error(
+      "프로필 사진 업로드 실패:",
+      error.response?.status,
+      error.response?.data || error.message
+    );
+    throw error;
+  }
+};
+
+// 프로필 사진 삭제
+export const deleteProfilePicture = async () => {
+  try {
+    const response = await api.delete("/api/user/profile-picture");
+    return response.data;
+  } catch (error) {
+    console.error("프로필 사진 삭제 실패:", error);
+    throw error;
+  }
+};

--- a/src/components/FeedbackCard.jsx
+++ b/src/components/FeedbackCard.jsx
@@ -56,7 +56,7 @@ function FeedbackCard({ feedback, userName, userAvatar, onClick }) {
       {/* 작성자 정보 및 시간 */}
       <div className="flex justify-between items-start mb-3">
         <div className="flex items-center gap-3">
-          <div className="w-[40px] h-[40px] rounded-full bg-green-100 border border-gray-300 flex items-center justify-center overflow-hidden">
+          <div className="w-[40px] h-[40px] rounded-full border border-gray-300 flex items-center justify-center overflow-hidden">
             {!userAvatar && (
               <span className="text-sm font-bold">{avatarInitial}</span>
             )}

--- a/src/components/FeedbackCard.jsx
+++ b/src/components/FeedbackCard.jsx
@@ -1,0 +1,129 @@
+import React, { useState } from "react";
+import { FaStar, FaHeart, FaRegHeart } from "react-icons/fa";
+import { TbMessage2Check } from "react-icons/tb";
+import { IoMdTime } from "react-icons/io";
+
+const formatTimeAgo = (dateString) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diff = (now - date) / 1000;
+
+  if (diff < 60) return "방금 전";
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  if (diff < 604800) return `${Math.floor(diff / 86400)}일 전`;
+
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(
+    2,
+    "0"
+  )}.${String(date.getDate()).padStart(2, "0")}`;
+};
+
+function FeedbackCard({ feedback, userName, userAvatar, onClick }) {
+  const {
+    feedbackId,
+    content,
+    rating,
+    adoptedTF,
+    likesCount,
+    createdAt,
+    postId,
+  } = feedback;
+
+  const [currentLikesCount, setCurrentLikesCount] = useState(likesCount);
+  const [isLiked, setIsLiked] = useState(false);
+
+  const displayContent =
+    content.length > 100 ? content.substring(0, 100) + "..." : content;
+  const avatarInitial = userName ? userName.charAt(0) : "U";
+
+  // 좋아요 버튼 클릭 핸들러
+  const handleToggleLike = (e) => {
+    e.stopPropagation();
+
+    setIsLiked((prev) => {
+      const next = !prev;
+      setCurrentLikesCount((c) => (next ? c + 1 : Math.max(0, c - 1)));
+      return next;
+    });
+  };
+
+  return (
+    <div
+      className="bg-white border rounded-lg p-5 shadow-sm transition duration-150 hover:shadow-md cursor-pointer flex flex-col justify-between h-full"
+      onClick={onClick} // 게시글 상세 페이지로 이동
+    >
+      {/* 작성자 정보 및 시간 */}
+      <div className="flex justify-between items-start mb-3">
+        <div className="flex items-center gap-3">
+          <div className="w-[40px] h-[40px] rounded-full bg-green-100 border border-gray-300 flex items-center justify-center overflow-hidden">
+            {!userAvatar && (
+              <span className="text-sm font-bold">{avatarInitial}</span>
+            )}
+            {userAvatar && (
+              <img
+                src={userAvatar}
+                alt={`${userName} 아바타`}
+                className="w-full h-full object-cover"
+              />
+            )}
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-semibold text-[14px]">
+                {userName || "작성자"}
+              </span>
+            </div>
+            <div className="text-[10px] text-gray-500">
+              <IoMdTime className="inline-block -mt-0.5 mr-1" />
+              {formatTimeAgo(createdAt)}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 평점 및 내용 */}
+      <div className="flex-1 mb-3">
+        <div className="flex items-center mb-2">
+          <FaStar className="text-base text-yellow-400 mr-1" />
+          <span className="text-sm font-bold text-gray-800 mt-0.5">
+            {rating.toFixed(1)}점
+          </span>
+        </div>
+
+        <p className="text-sm text-gray-700 leading-relaxed min-h-[40px]">
+          {displayContent || "내용 없음"}
+        </p>
+      </div>
+
+      {/* 좋아요 및 채택 여부 */}
+      <div className="border-t pt-3 mt-auto flex items-center justify-between">
+        <button
+          className="flex items-center gap-1 text-[#4D4D4D]"
+          onClick={handleToggleLike}
+          type="button"
+          aria-label="좋아요"
+        >
+          {isLiked ? <FaHeart className="text-red-500" /> : <FaRegHeart />}
+          <span className="text-[10px] font-medium">
+            {currentLikesCount.toLocaleString()}
+          </span>
+        </button>
+
+        {/* 채택 여부 */}
+        {adoptedTF ? (
+          <div className="flex items-center bg-[#D1FAE5] text-[#059669] px-2 py-0.5 rounded-full text-xs font-semibold shrink-0">
+            <TbMessage2Check size={14} className="mr-1" />
+            채택 완료
+          </div>
+        ) : (
+          <div className="flex items-center bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full text-xs font-semibold shrink-0">
+            채택 대기
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FeedbackCard;

--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -66,7 +66,7 @@ function PostCard({
       {/* 상단: 작성자/시간 */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-3">
-          <div className="w-[40px] h-[40px] rounded-full bg-green-100 border border-gray-300 flex items-center justify-center overflow-hidden">
+          <div className="w-[40px] h-[40px] rounded-full border border-gray-300 flex items-center justify-center overflow-hidden">
             <img
               src={avatar}
               alt="profile"

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -22,6 +22,16 @@ function Main() {
         const data = await fetchMain();
         if (!ignore) {
           setMainData(data);
+          if (data?.userInfo?.userId) {
+            localStorage.setItem(
+              "loggedInUserId",
+              String(data.userInfo.userId)
+            );
+            console.log(
+              "Main: 로그인된 사용자 ID 저장 완료:",
+              data.userInfo.userId
+            );
+          }
         }
       } catch (err) {
         console.error("메인 데이터 조회 실패:", err);

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -327,11 +327,28 @@ function MyPaged() {
   const isFeedbackExpanded = myFeedbackCount >= profile.feedbackCount;
   const isScrapsExpanded = myScrapsCount >= profile.scrapCount;
 
-  const GradeDonut = ({ percent = 50, label = "등급" }) => {
+  // 등급별 도넛 채움 비율 매핑
+  const getGradeFillPercent = (grade) => {
+    switch (grade) {
+      case "숲의 현자":
+        return 100;
+      case "나무 개발자":
+        return 75;
+      case "잎새 개발자":
+        return 50;
+      case "새싹 개발자":
+      default:
+        return 25;
+    }
+  };
+
+  const GradeDonut = ({ label = "등급" }) => {
     const size = 120;
     const stroke = 12;
     const r = (size - stroke) / 2;
     const c = 2 * Math.PI * r;
+    산;
+    const percent = getGradeFillPercent(label);
     const dash = (percent / 100) * c;
 
     return (
@@ -456,10 +473,7 @@ function MyPaged() {
                 </ul>
               </div>
               <div className="shrink-0 ml-16 mr-5">
-                <GradeDonut
-                  percent={profile.selectRate}
-                  label={profile.gradeLabel}
-                />
+                <GradeDonut label={profile.gradeLabel} />
               </div>
             </div>
           </div>

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from "react";
 import Header from "../components/header/Header";
-import baseProfile from "../assets/profile.png";
+import baseProfile from "../assets/baseProfile.png";
 import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
 import { VscFeedback } from "react-icons/vsc";
 import { FaRegBookmark } from "react-icons/fa"; // 스크랩 아이콘 추가

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -3,13 +3,14 @@ import Header from "../components/header/Header";
 import baseProfile from "../assets/profile.png";
 import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
 import { VscFeedback } from "react-icons/vsc";
-import samplePosts from "../components/postcontext.jsx";
 import PostCard from "../components/PostCard.jsx";
+import FeedbackCard from "../components/FeedbackCard.jsx";
 import { useNavigate } from "react-router-dom";
 import {
   getUserProfile,
   getUserRecentPosts,
   getUserPosts,
+  getUserRecentFeedbacks,
 } from "../api/userApi";
 import { makeAbsoluteImageUrl } from "../utils/imageHelper";
 
@@ -49,9 +50,9 @@ function MyPaged() {
   const [activeTab, setActiveTab] = useState("posts");
   const INITIAL_COUNT = 4;
   const [myPostsDisplayCount, setMyPostsDisplayCount] = useState(INITIAL_COUNT);
-
-  const myFeedbackAll = samplePosts;
+  const [myFeedbackAll, setMyFeedbackAll] = useState([]);
   const [myFeedbackCount, setMyFeedbackCount] = useState(INITIAL_COUNT);
+  const [hasFetchedAllFeedbacks, setHasFetchedAllFeedbacks] = useState(false);
 
   const postsRef = useRef(null);
   const feedbackRef = useRef(null);
@@ -83,11 +84,14 @@ function MyPaged() {
 
         // 최근 게시글 조회 (초기 4개 데이터)
         const postsRes = await getUserRecentPosts(currentUserId);
-        // postsRes.data 자체가 배열임
         const mappedPosts = postsRes.data.map((post) =>
           mapApiToPostData(post, pData)
         );
         setMyPosts(mappedPosts);
+
+        // 최근 피드백 조회 (초기 4개 데이터)
+        const feedbacksRes = await getUserRecentFeedbacks(currentUserId);
+        setMyFeedbackAll(feedbacksRes.data);
       } catch (error) {
         console.error("데이터 로딩 중 오류 발생:", error);
       }
@@ -149,7 +153,10 @@ function MyPaged() {
     postsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  const expandFeedback = () => setMyFeedbackCount(myFeedbackAll.length);
+  const expandFeedback = () => {
+    setMyFeedbackCount(myFeedbackAll.length);
+  };
+
   const collapseFeedback = () => {
     setMyFeedbackCount(INITIAL_COUNT);
     feedbackRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -336,17 +343,24 @@ function MyPaged() {
                 </h2>
               </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {myFeedbackAll.slice(0, myFeedbackCount).map((p) => (
-                  <PostCard
-                    key={`myfb-${p.id}`}
-                    {...p}
-                    badge="내 피드백"
-                    rightPill={null}
-                    onClick={() => handlePostClick(p.id)}
-                  />
-                ))}
-              </div>
+              {myFeedbackAll.length === 0 ? (
+                <div className="text-center py-10 text-gray-500">
+                  등록된 피드백이 없습니다.
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {myFeedbackAll.slice(0, myFeedbackCount).map((feedback) => (
+                    <FeedbackCard
+                      key={`myfb-${feedback.feedbackId}`}
+                      feedback={feedback}
+                      userName={profile.name}
+                      userAvatar={profileImgSrc}
+                      // 클릭 시 해당 피드백이 달린 게시글로 이동
+                      onClick={() => handlePostClick(feedback.postId)}
+                    />
+                  ))}
+                </div>
+              )}
 
               <div className="mt-6 flex items-center justify-center gap-2">
                 {myFeedbackAll.length > INITIAL_COUNT &&

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -3,6 +3,7 @@ import Header from "../components/header/Header";
 import baseProfile from "../assets/profile.png";
 import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
 import { VscFeedback } from "react-icons/vsc";
+import { FaRegBookmark } from "react-icons/fa"; // 스크랩 아이콘 추가
 import PostCard from "../components/PostCard.jsx";
 import FeedbackCard from "../components/FeedbackCard.jsx";
 import { useNavigate } from "react-router-dom";
@@ -12,6 +13,8 @@ import {
   getUserPosts,
   getUserRecentFeedbacks,
   getUserFeedbacks,
+  getUserRecentScraps,
+  getUserScraps,
 } from "../api/userApi";
 import { makeAbsoluteImageUrl } from "../utils/imageHelper";
 
@@ -43,6 +46,7 @@ function MyPaged() {
     selectRate: 0,
     postCount: 0,
     feedbackCount: 0,
+    scrapCount: 0,
     gradeLabel: "Loading",
   });
 
@@ -51,12 +55,18 @@ function MyPaged() {
   const [activeTab, setActiveTab] = useState("posts");
   const INITIAL_COUNT = 4;
   const [myPostsDisplayCount, setMyPostsDisplayCount] = useState(INITIAL_COUNT);
+
   const [myFeedbackAll, setMyFeedbackAll] = useState([]);
   const [myFeedbackCount, setMyFeedbackCount] = useState(INITIAL_COUNT);
   const [hasFetchedAllFeedbacks, setHasFetchedAllFeedbacks] = useState(false);
 
+  const [myScraps, setMyScraps] = useState([]);
+  const [myScrapsCount, setMyScrapsCount] = useState(INITIAL_COUNT);
+  const [hasFetchedAllScraps, setHasFetchedAllScraps] = useState(false);
+
   const postsRef = useRef(null);
   const feedbackRef = useRef(null);
+  const scrapsRef = useRef(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -73,13 +83,24 @@ function MyPaged() {
               )
             : 0;
 
+        // 최근 스크랩 조회 (초기 4개 데이터)
+        const scrapsRes = await getUserRecentScraps(currentUserId);
+        const mappedScraps = scrapsRes.data.map((post) =>
+          mapApiToPostData(post, pData)
+        );
+        setMyScraps(mappedScraps);
+
+        // 스크랩 수 계산
+        const calculatedScrapCount = mappedScraps.length;
+
         setProfile({
           name: pData.userName,
           avatar: pData.userPicture,
           points: pData.points,
           selectRate: selectRate,
-          postCount: pData.postCount, // 총 게시글 수
-          feedbackCount: pData.totalFeedbackCount, // 총 피드백 수
+          postCount: pData.postCount,
+          feedbackCount: pData.totalFeedbackCount,
+          scrapCount: pData.scrapCount || calculatedScrapCount,
           gradeLabel: pData.grade,
         });
 
@@ -180,9 +201,36 @@ function MyPaged() {
     feedbackRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
+  // 스크랩 더보기 버튼 클릭 시
+  const expandScraps = async () => {
+    if (!hasFetchedAllScraps) {
+      try {
+        const res = await getUserScraps(currentUserId, 0, profile.scrapCount);
+        const contentList = res.data.content || [];
+        const allScrapsMapped = contentList.map((post) =>
+          mapApiToPostData(post, profile)
+        );
+
+        setMyScraps(allScrapsMapped);
+        setHasFetchedAllScraps(true);
+        setMyScrapsCount(allScrapsMapped.length);
+      } catch (e) {
+        console.error("전체 스크랩 로딩 실패", e);
+      }
+    } else {
+      setMyScrapsCount(myScraps.length);
+    }
+  };
+
+  const collapseScraps = () => {
+    setMyScrapsCount(INITIAL_COUNT);
+    scrapsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   const profileImgSrc = makeAbsoluteImageUrl(profile.avatar) || baseProfile;
   const isPostsExpanded = myPostsDisplayCount >= profile.postCount;
   const isFeedbackExpanded = myFeedbackCount >= profile.feedbackCount;
+  const isScrapsExpanded = myScrapsCount >= profile.scrapCount;
 
   const GradeDonut = ({ percent = 50, label = "등급" }) => {
     const size = 120;
@@ -301,6 +349,16 @@ function MyPaged() {
             >
               내 피드백 ({profile.feedbackCount})
             </button>
+            <button
+              onClick={() => setActiveTab("scraps")}
+              className={`px-3 py-1.5 rounded-full text-sm border transition ${
+                activeTab === "scraps"
+                  ? "bg-[#00B834] text-white border-[#00B834]"
+                  : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+              }`}
+            >
+              내 스크랩 ({profile.scrapCount})
+            </button>
           </div>
 
           {/* 내 게시글 영역 */}
@@ -330,7 +388,6 @@ function MyPaged() {
                 </div>
               )}
 
-              {/* 더보기/접기 버튼 */}
               <div className="mt-6 flex items-center justify-center gap-2">
                 {profile.postCount > INITIAL_COUNT && !isPostsExpanded && (
                   <button
@@ -340,7 +397,6 @@ function MyPaged() {
                     더보기
                   </button>
                 )}
-                {/* 전체 게시글이 표시되었을 때 */}
                 {profile.postCount > INITIAL_COUNT && isPostsExpanded && (
                   <button
                     onClick={collapsePosts}
@@ -374,7 +430,6 @@ function MyPaged() {
                       feedback={feedback}
                       userName={profile.name}
                       userAvatar={profileImgSrc}
-                      // 클릭 시 해당 피드백이 달린 게시글로 이동
                       onClick={() => handlePostClick(feedback.postId)}
                     />
                   ))}
@@ -391,7 +446,6 @@ function MyPaged() {
                       더보기
                     </button>
                   )}
-                {/* 전체 피드백이 표시되었을 때 */}
                 {profile.feedbackCount > INITIAL_COUNT &&
                   isFeedbackExpanded && (
                     <button
@@ -401,6 +455,56 @@ function MyPaged() {
                       접기
                     </button>
                   )}
+              </div>
+            </section>
+          )}
+
+          {/* 내 스크랩 영역 */}
+          {activeTab === "scraps" && (
+            <section ref={scrapsRef} className="mb-10">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-[16px] font-semibold ml-1">
+                  내가 스크랩한 게시글
+                </h2>
+              </div>
+              {myScraps.length === 0 ? (
+                <div className="text-center py-10 text-gray-500">
+                  스크랩한 게시글이 없습니다.
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {myScraps.slice(0, myScrapsCount).map((p) => (
+                    <PostCard
+                      key={`myscrap-${p.id}`}
+                      {...p}
+                      avatar={makeAbsoluteImageUrl(p.avatar) || baseProfile}
+                      badge="스크랩"
+                      rightPill={null}
+                      onClick={() => handlePostClick(p.id)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {/* 스크랩 더보기/접기 버튼 */}
+              <div className="mt-6 flex items-center justify-center gap-2">
+                {profile.scrapCount > INITIAL_COUNT && !isScrapsExpanded && (
+                  <button
+                    onClick={expandScraps}
+                    className="px-4 py-2 text-sm rounded-md border border-[#00B834] text-[#00B834] hover:bg-[#00B834]/5"
+                  >
+                    더보기
+                  </button>
+                )}
+                {/* 전체 스크랩이 표시되었을 때 */}
+                {profile.scrapCount > INITIAL_COUNT && isScrapsExpanded && (
+                  <button
+                    onClick={collapseScraps}
+                    className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                  >
+                    접기
+                  </button>
+                )}
               </div>
             </section>
           )}

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -1,11 +1,13 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import Header from "../components/header/Header";
-import profileImg from "../assets/profile.png";
+import baseProfile from "../assets/profile.png";
 import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
 import { VscFeedback } from "react-icons/vsc";
 import samplePosts from "../components/postcontext.jsx";
 import PostCard from "../components/PostCard.jsx";
 import { useNavigate } from "react-router-dom";
+import { getUserProfile } from "../api/userApi";
+import { makeAbsoluteImageUrl } from "../utils/imageHelper";
 
 function MyPaged() {
   const navigate = useNavigate();
@@ -14,17 +16,55 @@ function MyPaged() {
     navigate(`/posts/${postId}`);
   };
 
-  const profile = {
-    name: "Chiikawa",
-    avatar: profileImg,
-    points: 4300,
-    selectRate: 50,
-    postCount: 3,
-    feedbackCount: 5,
-    gradeLabel: "등급",
-  };
+  const [profile, setProfile] = useState({
+    name: "Loading...",
+    avatar: null,
+    points: 0,
+    selectRate: 0,
+    postCount: 0,
+    feedbackCount: 0,
+    gradeLabel: "Loading",
+  });
 
-  // === Donut ===
+  useEffect(() => {
+    const currentUserId = 1;
+
+    const loadProfile = async () => {
+      try {
+        const res = await getUserProfile(currentUserId);
+        const data = res.data;
+
+        // 피드백 채택률 계산
+        const selectRate =
+          data.totalFeedbackCount > 0
+            ? Math.round(
+                (data.adoptedFeedbackCount / data.totalFeedbackCount) * 100
+              )
+            : 0;
+        setProfile({
+          name: data.userName,
+          avatar: data.userPicture,
+          points: data.points,
+          selectRate: selectRate,
+          postCount: data.postCount,
+          feedbackCount: data.totalFeedbackCount,
+          gradeLabel: data.grade,
+        });
+      } catch (error) {
+        console.error("프로필 로딩 중 오류 발생:", error);
+        setProfile((prev) => ({
+          ...prev,
+          name: "데이터 로딩 오류",
+          gradeLabel: "N/A",
+        }));
+      }
+    };
+
+    loadProfile();
+  }, []);
+
+  const profileImgSrc = makeAbsoluteImageUrl(profile.avatar) || baseProfile;
+
   const GradeDonut = ({ percent = 50, label = "등급" }) => {
     const size = 120;
     const stroke = 12;
@@ -63,15 +103,14 @@ function MyPaged() {
     );
   };
 
-  const myPostsAll = samplePosts; // 임시 데이터 가져옴
+  const myPostsAll = samplePosts;
   const myFeedbackAll = samplePosts;
 
-  const INITIAL_COUNT = 4; // 기본 노출 게시글은 4개
-  const [activeTab, setActiveTab] = useState("posts"); // 'posts' | 'feedback'
+  const INITIAL_COUNT = 4;
+  const [activeTab, setActiveTab] = useState("posts");
   const [myPostsCount, setMyPostsCount] = useState(INITIAL_COUNT);
   const [myFeedbackCount, setMyFeedbackCount] = useState(INITIAL_COUNT);
 
-  // 접기 버튼 클릭 시 스크롤 복귀
   const postsRef = useRef(null);
   const feedbackRef = useRef(null);
 
@@ -99,9 +138,13 @@ function MyPaged() {
             {/* 프로필 */}
             <div className="h-full w-[132px] overflow-hidden rounded-[10px]">
               <img
-                src={profile.avatar}
+                src={profileImgSrc}
                 alt={`${profile.name} 프로필`}
                 className="h-full w-full object-cover"
+                onError={(e) => {
+                  e.currentTarget.onerror = null;
+                  e.currentTarget.src = baseProfile;
+                }}
               />
             </div>
 

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -49,6 +49,7 @@ function MyPaged() {
   const [activeTab, setActiveTab] = useState("posts");
   const INITIAL_COUNT = 4;
   const [myPostsDisplayCount, setMyPostsDisplayCount] = useState(INITIAL_COUNT);
+
   const myFeedbackAll = samplePosts;
   const [myFeedbackCount, setMyFeedbackCount] = useState(INITIAL_COUNT);
 
@@ -82,6 +83,7 @@ function MyPaged() {
 
         // 최근 게시글 조회 (초기 4개 데이터)
         const postsRes = await getUserRecentPosts(currentUserId);
+        // postsRes.data 자체가 배열임
         const mappedPosts = postsRes.data.map((post) =>
           mapApiToPostData(post, pData)
         );
@@ -119,15 +121,18 @@ function MyPaged() {
     navigate(`/posts/${postId}`);
   };
 
-  // 게시글 더보기 버튼 클릭 시
+  // 게시글 더보기 버튼 클릭 시 (전체/페이징 API 호출)
   const expandPosts = async () => {
     // 아직 전체 데이터를 불러오지 않았고, 실제로 더 불러올 데이터가 있는 경우 (현재 개수 < 총 개수)
-    if (!hasFetchedAllPosts && myPosts.length < profile.postCount) {
+    if (!hasFetchedAllPosts) {
       try {
         const res = await getUserPosts(currentUserId, 0, 100);
-        const allPostsMapped = res.data.content.map((post) =>
+        const contentList = res.data.content || [];
+
+        const allPostsMapped = contentList.map((post) =>
           mapApiToPostData(post, profile)
         );
+
         setMyPosts(allPostsMapped);
         setHasFetchedAllPosts(true);
         setMyPostsDisplayCount(allPostsMapped.length);
@@ -151,7 +156,7 @@ function MyPaged() {
   };
 
   const profileImgSrc = makeAbsoluteImageUrl(profile.avatar) || baseProfile;
-  const isPostsExpanded = myPostsDisplayCount >= profile.postCount; // 총 개수 기준
+  const isPostsExpanded = myPostsDisplayCount >= profile.postCount;
   const isFeedbackExpanded = myFeedbackCount >= myFeedbackAll.length;
 
   const GradeDonut = ({ percent = 50, label = "등급" }) => {

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -3,10 +3,9 @@ import Header from "../components/header/Header";
 import baseProfile from "../assets/baseProfile.png";
 import { TbCoin, TbMessage2Check, TbPencil } from "react-icons/tb";
 import { VscFeedback } from "react-icons/vsc";
-import { FaRegBookmark } from "react-icons/fa"; // 스크랩 아이콘 추가
+import { useNavigate, useParams } from "react-router-dom";
 import PostCard from "../components/PostCard.jsx";
 import FeedbackCard from "../components/FeedbackCard.jsx";
-import { useNavigate } from "react-router-dom";
 import {
   getUserProfile,
   getUserRecentPosts,
@@ -18,7 +17,7 @@ import {
 } from "../api/userApi";
 import { makeAbsoluteImageUrl } from "../utils/imageHelper";
 
-// 날짜 포맷팅
+// 날짜 포맷팅 함수 (생략되지 않도록 유지)
 const formatTimeAgo = (dateString) => {
   const date = new Date(dateString);
   const now = new Date();
@@ -37,7 +36,19 @@ const formatTimeAgo = (dateString) => {
 
 function MyPaged() {
   const navigate = useNavigate();
-  const currentUserId = 1;
+  const { userId: urlUserId } = useParams();
+
+  // 로그인 ID 추출
+  const loggedInUserId = localStorage.getItem("loggedInUserId");
+  const isLoggedIn = !!loggedInUserId;
+
+  // 조회 대상 ID 결정
+  const targetUserId = urlUserId ? urlUserId : loggedInUserId;
+
+  // 본인 프로필 여부 결정
+  const isMyProfile =
+    isLoggedIn &&
+    (!urlUserId || (urlUserId && targetUserId === loggedInUserId)); // targetUserId로 비교하도록 수정
 
   const [profile, setProfile] = useState({
     name: "Loading...",
@@ -69,10 +80,27 @@ function MyPaged() {
   const scrapsRef = useRef(null);
 
   useEffect(() => {
+    // 로그인 확인 및 리다이렉션
+    if (!urlUserId && !isLoggedIn) {
+      alert("로그인이 필요합니다.");
+      navigate("/sign-in");
+      return;
+    }
+    if (!targetUserId) {
+      console.error(
+        "조회할 사용자 ID가 유효하지 않아 데이터 로딩을 중단합니다."
+      );
+      return;
+    }
+
+    // 타인 프로필을 볼 때 스크랩 탭이 선택되어 있다면 게시글 탭으로 초기화
+    if (!isMyProfile && activeTab === "scraps") {
+      setActiveTab("posts");
+    }
+
     const fetchData = async () => {
       try {
-        // 프로필 조회
-        const profileRes = await getUserProfile(currentUserId);
+        const profileRes = await getUserProfile(targetUserId);
         const pData = profileRes.data;
 
         // 피드백 채택률 계산
@@ -83,15 +111,18 @@ function MyPaged() {
               )
             : 0;
 
-        // 최근 스크랩 조회 (초기 4개 데이터)
-        const scrapsRes = await getUserRecentScraps(currentUserId);
-        const mappedScraps = scrapsRes.data.map((post) =>
-          mapApiToPostData(post, pData)
-        );
-        setMyScraps(mappedScraps);
-
-        // 스크랩 수 계산
-        const calculatedScrapCount = mappedScraps.length;
+        // 스크랩은 본인 프로필일 때만
+        let calculatedScrapCount = 0;
+        if (isMyProfile) {
+          const scrapsRes = await getUserRecentScraps(targetUserId);
+          const mappedScraps = scrapsRes.data.map((post) =>
+            mapApiToPostData(post, pData)
+          );
+          setMyScraps(mappedScraps);
+          calculatedScrapCount = pData.scrapCount || mappedScraps.length;
+        } else {
+          setMyScraps([]);
+        }
 
         setProfile({
           name: pData.userName,
@@ -100,27 +131,35 @@ function MyPaged() {
           selectRate: selectRate,
           postCount: pData.postCount,
           feedbackCount: pData.totalFeedbackCount,
-          scrapCount: pData.scrapCount || calculatedScrapCount,
+          scrapCount: isMyProfile ? calculatedScrapCount : 0,
           gradeLabel: pData.grade,
         });
 
-        // 최근 게시글 조회 (초기 4개 데이터)
-        const postsRes = await getUserRecentPosts(currentUserId);
+        // 최근 게시글 조회
+        const postsRes = await getUserRecentPosts(targetUserId);
         const mappedPosts = postsRes.data.map((post) =>
           mapApiToPostData(post, pData)
         );
         setMyPosts(mappedPosts);
 
-        // 최근 피드백 조회 (초기 4개 데이터)
-        const feedbacksRes = await getUserRecentFeedbacks(currentUserId);
+        // 최근 피드백 조회
+        const feedbacksRes = await getUserRecentFeedbacks(targetUserId);
         setMyFeedbackAll(feedbacksRes.data);
       } catch (error) {
         console.error("데이터 로딩 중 오류 발생:", error);
+        alert("프로필 데이터를 불러오는 데 실패했습니다.");
       }
     };
 
     fetchData();
-  }, []);
+  }, [
+    targetUserId,
+    loggedInUserId,
+    navigate,
+    urlUserId,
+    activeTab,
+    isMyProfile,
+  ]);
 
   const mapApiToPostData = (apiPost, profileData) => {
     return {
@@ -151,7 +190,7 @@ function MyPaged() {
   const expandPosts = async () => {
     if (!hasFetchedAllPosts) {
       try {
-        const res = await getUserPosts(currentUserId, 0, profile.postCount);
+        const res = await getUserPosts(targetUserId, 0, profile.postCount);
         const contentList = res.data.content || [];
 
         const allPostsMapped = contentList.map((post) =>
@@ -179,7 +218,7 @@ function MyPaged() {
     if (!hasFetchedAllFeedbacks) {
       try {
         const res = await getUserFeedbacks(
-          currentUserId,
+          targetUserId,
           0,
           profile.feedbackCount
         );
@@ -203,9 +242,11 @@ function MyPaged() {
 
   // 스크랩 더보기 버튼 클릭 시
   const expandScraps = async () => {
+    if (!isMyProfile) return;
+
     if (!hasFetchedAllScraps) {
       try {
-        const res = await getUserScraps(currentUserId, 0, profile.scrapCount);
+        const res = await getUserScraps(targetUserId, 0, profile.scrapCount);
         const contentList = res.data.content || [];
         const allScrapsMapped = contentList.map((post) =>
           mapApiToPostData(post, profile)
@@ -337,7 +378,7 @@ function MyPaged() {
                   : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
               }`}
             >
-              내 게시글 ({profile.postCount})
+              게시글 ({profile.postCount})
             </button>
             <button
               onClick={() => setActiveTab("feedback")}
@@ -347,18 +388,22 @@ function MyPaged() {
                   : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
               }`}
             >
-              내 피드백 ({profile.feedbackCount})
+              피드백 ({profile.feedbackCount})
             </button>
-            <button
-              onClick={() => setActiveTab("scraps")}
-              className={`px-3 py-1.5 rounded-full text-sm border transition ${
-                activeTab === "scraps"
-                  ? "bg-[#00B834] text-white border-[#00B834]"
-                  : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
-              }`}
-            >
-              내 스크랩 ({profile.scrapCount})
-            </button>
+
+            {/* 스크랩 탭 */}
+            {isMyProfile && (
+              <button
+                onClick={() => setActiveTab("scraps")}
+                className={`px-3 py-1.5 rounded-full text-sm border transition ${
+                  activeTab === "scraps"
+                    ? "bg-[#00B834] text-white border-[#00B834]"
+                    : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+                }`}
+              >
+                스크랩 ({profile.scrapCount})
+              </button>
+            )}
           </div>
 
           {/* 내 게시글 영역 */}
@@ -366,7 +411,9 @@ function MyPaged() {
             <section ref={postsRef} className="mb-10">
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-[16px] font-semibold ml-1">
-                  내가 올린 게시글
+                  {isMyProfile
+                    ? "내가 올린 게시글"
+                    : `${profile.name} 님의 게시글`}
                 </h2>
               </div>
               {myPosts.length === 0 ? (
@@ -380,7 +427,7 @@ function MyPaged() {
                       key={`mypost-${p.id}`}
                       {...p}
                       avatar={makeAbsoluteImageUrl(p.avatar) || baseProfile}
-                      badge="내 게시글"
+                      badge={isMyProfile ? "내 게시글" : null}
                       rightPill={null}
                       onClick={() => handlePostClick(p.id)}
                     />
@@ -414,7 +461,9 @@ function MyPaged() {
             <section ref={feedbackRef} className="mb-2">
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-[16px] font-semibold ml-1">
-                  내가 등록한 피드백
+                  {isMyProfile
+                    ? "내가 등록한 피드백"
+                    : `${profile.name} 님의 피드백`}
                 </h2>
               </div>
 
@@ -459,8 +508,8 @@ function MyPaged() {
             </section>
           )}
 
-          {/* 내 스크랩 영역 */}
-          {activeTab === "scraps" && (
+          {/* 내 스크랩 영역 (본인에게만 표시) */}
+          {activeTab === "scraps" && isMyProfile && (
             <section ref={scrapsRef} className="mb-10">
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-[16px] font-semibold ml-1">

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -14,10 +14,12 @@ import {
   getUserFeedbacks,
   getUserRecentScraps,
   getUserScraps,
+  updateProfilePicture,
+  deleteProfilePicture,
 } from "../api/userApi";
 import { makeAbsoluteImageUrl } from "../utils/imageHelper";
 
-// 날짜 포맷팅 함수 (생략되지 않도록 유지)
+// 날짜 포맷팅 함수
 const formatTimeAgo = (dateString) => {
   const date = new Date(dateString);
   const now = new Date();
@@ -48,7 +50,7 @@ function MyPaged() {
   // 본인 프로필 여부 결정
   const isMyProfile =
     isLoggedIn &&
-    (!urlUserId || (urlUserId && targetUserId === loggedInUserId)); // targetUserId로 비교하도록 수정
+    (!urlUserId || (urlUserId && targetUserId === loggedInUserId));
 
   const [profile, setProfile] = useState({
     name: "Loading...",
@@ -78,6 +80,7 @@ function MyPaged() {
   const postsRef = useRef(null);
   const feedbackRef = useRef(null);
   const scrapsRef = useRef(null);
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     // 로그인 확인 및 리다이렉션
@@ -184,6 +187,57 @@ function MyPaged() {
 
   const handlePostClick = (postId) => {
     navigate(`/posts/${postId}`);
+  };
+
+  // 파일 업로드
+  const handleImageUpload = async (event) => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    if (!file.type.startsWith("image/")) {
+      alert("이미지 파일만 업로드할 수 있습니다.");
+      return;
+    }
+
+    try {
+      const newImagePath = await updateProfilePicture(file);
+      setProfile((prev) => ({
+        ...prev,
+        avatar: newImagePath,
+      }));
+
+      alert("프로필 사진이 성공적으로 변경되었습니다.");
+    } catch (error) {
+      console.error("프로필 사진 업로드 실패:", error);
+      alert("프로필 사진 변경에 실패했습니다. 다시 시도해 주세요.");
+    } finally {
+      event.target.value = null;
+    }
+  };
+
+  // 프로필 사진 삭제
+  const handleDeleteProfilePicture = async () => {
+    if (!profile.avatar) {
+      alert("삭제할 프로필 사진이 없습니다.");
+      return;
+    }
+
+    const confirmed = window.confirm(
+      "프로필 사진을 삭제하고 기본 이미지로 되돌리시겠습니까?"
+    );
+    if (!confirmed) return;
+
+    try {
+      await deleteProfilePicture();
+      setProfile((prev) => ({
+        ...prev,
+        avatar: null,
+      }));
+      alert("프로필 사진이 삭제되었습니다.");
+    } catch (error) {
+      console.error("프로필 사진 삭제 실패:", error);
+      alert("프로필 사진 삭제에 실패했습니다. 다시 시도해 주세요.");
+    }
   };
 
   // 게시글 더보기 버튼 클릭 시 (전체/페이징 API 호출)
@@ -318,17 +372,59 @@ function MyPaged() {
         <div className="rounded-[10px] border border-gray-200 bg-white px-10 py-5 shadow-sm">
           {/* 프로필 */}
           <div className="flex items-center gap-5 px-20 mb-10">
-            <div className="h-full w-[132px] overflow-hidden rounded-[10px]">
-              <img
-                src={profileImgSrc}
-                alt={`${profile.name} 프로필`}
-                className="h-full w-full object-cover"
-                onError={(e) => {
-                  e.currentTarget.onerror = null;
-                  e.currentTarget.src = baseProfile;
-                }}
-              />
+            {/* 프로필 이미지 영역 */}
+            <div
+              className={`h-full w-[132px] relative ${
+                isMyProfile ? "cursor-pointer" : ""
+              }`}
+              onClick={() => isMyProfile && fileInputRef.current?.click()}
+            >
+              <div
+                className={`h-full w-full overflow-hidden rounded-[10px] ${
+                  isMyProfile ? "group" : ""
+                }`}
+              >
+                {/* 이미지 태그 */}
+                <img
+                  src={profileImgSrc}
+                  alt={`${profile.name} 프로필`}
+                  className="h-full w-full object-cover"
+                  onError={(e) => {
+                    e.currentTarget.onerror = null;
+                    e.currentTarget.src = baseProfile;
+                  }}
+                />
+                {isMyProfile && (
+                  <div className="absolute inset-0 bg-black bg-opacity-30 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                    <TbPencil size={24} className="text-white" />
+                  </div>
+                )}
+              </div>
+
+              {/* 삭제 버튼 */}
+              {isMyProfile && profile.avatar && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDeleteProfilePicture();
+                  }}
+                  className="absolute top-1 right-1 w-5 h-5 rounded-full bg-black/70 text-white text-[12px] flex items-center justify-center hover:bg-black"
+                >
+                  ×
+                </button>
+              )}
+              {isMyProfile && (
+                <input
+                  type="file"
+                  ref={fileInputRef}
+                  onChange={handleImageUpload}
+                  accept="image/*"
+                  style={{ display: "none" }}
+                />
+              )}
             </div>
+
             <div className="flex-1 w-[825px] rounded-[10px] border border-[#ACACAC] bg-white pl-6 pr-3 py-4 flex items-center justify-between box-border overflow-hidden">
               <div className="flex-1 min-w-0">
                 <h2 className="text-[22px] font-semibold mb-2">
@@ -391,7 +487,6 @@ function MyPaged() {
               피드백 ({profile.feedbackCount})
             </button>
 
-            {/* 스크랩 탭 */}
             {isMyProfile && (
               <button
                 onClick={() => setActiveTab("scraps")}
@@ -535,7 +630,6 @@ function MyPaged() {
                 </div>
               )}
 
-              {/* 스크랩 더보기/접기 버튼 */}
               <div className="mt-6 flex items-center justify-center gap-2">
                 {profile.scrapCount > INITIAL_COUNT && !isScrapsExpanded && (
                   <button
@@ -545,7 +639,6 @@ function MyPaged() {
                     더보기
                   </button>
                 )}
-                {/* 전체 스크랩이 표시되었을 때 */}
                 {profile.scrapCount > INITIAL_COUNT && isScrapsExpanded && (
                   <button
                     onClick={collapseScraps}

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -347,7 +347,6 @@ function MyPaged() {
     const stroke = 12;
     const r = (size - stroke) / 2;
     const c = 2 * Math.PI * r;
-    산;
     const percent = getGradeFillPercent(label);
     const dash = (percent / 100) * c;
 

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -6,15 +6,33 @@ import { VscFeedback } from "react-icons/vsc";
 import samplePosts from "../components/postcontext.jsx";
 import PostCard from "../components/PostCard.jsx";
 import { useNavigate } from "react-router-dom";
-import { getUserProfile } from "../api/userApi";
+import {
+  getUserProfile,
+  getUserRecentPosts,
+  getUserPosts,
+} from "../api/userApi";
 import { makeAbsoluteImageUrl } from "../utils/imageHelper";
+
+// 날짜 포맷팅
+const formatTimeAgo = (dateString) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diff = (now - date) / 1000;
+
+  if (diff < 60) return "방금 전";
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`;
+  if (diff < 604800) return `${Math.floor(diff / 86400)}일 전`;
+
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(
+    2,
+    "0"
+  )}.${String(date.getDate()).padStart(2, "0")}`;
+};
 
 function MyPaged() {
   const navigate = useNavigate();
-
-  const handlePostClick = (postId) => {
-    navigate(`/posts/${postId}`);
-  };
+  const currentUserId = 1;
 
   const [profile, setProfile] = useState({
     name: "Loading...",
@@ -26,44 +44,115 @@ function MyPaged() {
     gradeLabel: "Loading",
   });
 
-  useEffect(() => {
-    const currentUserId = 1;
+  const [myPosts, setMyPosts] = useState([]);
+  const [hasFetchedAllPosts, setHasFetchedAllPosts] = useState(false);
+  const [activeTab, setActiveTab] = useState("posts");
+  const INITIAL_COUNT = 4;
+  const [myPostsDisplayCount, setMyPostsDisplayCount] = useState(INITIAL_COUNT);
+  const myFeedbackAll = samplePosts;
+  const [myFeedbackCount, setMyFeedbackCount] = useState(INITIAL_COUNT);
 
-    const loadProfile = async () => {
+  const postsRef = useRef(null);
+  const feedbackRef = useRef(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
       try {
-        const res = await getUserProfile(currentUserId);
-        const data = res.data;
+        // 프로필 조회
+        const profileRes = await getUserProfile(currentUserId);
+        const pData = profileRes.data;
 
         // 피드백 채택률 계산
         const selectRate =
-          data.totalFeedbackCount > 0
+          pData.totalFeedbackCount > 0
             ? Math.round(
-                (data.adoptedFeedbackCount / data.totalFeedbackCount) * 100
+                (pData.adoptedFeedbackCount / pData.totalFeedbackCount) * 100
               )
             : 0;
+
         setProfile({
-          name: data.userName,
-          avatar: data.userPicture,
-          points: data.points,
+          name: pData.userName,
+          avatar: pData.userPicture,
+          points: pData.points,
           selectRate: selectRate,
-          postCount: data.postCount,
-          feedbackCount: data.totalFeedbackCount,
-          gradeLabel: data.grade,
+          postCount: pData.postCount,
+          feedbackCount: pData.totalFeedbackCount,
+          gradeLabel: pData.grade,
         });
+
+        // 최근 게시글 조회 (초기 4개 데이터)
+        const postsRes = await getUserRecentPosts(currentUserId);
+        const mappedPosts = postsRes.data.map((post) =>
+          mapApiToPostData(post, pData)
+        );
+        setMyPosts(mappedPosts);
       } catch (error) {
-        console.error("프로필 로딩 중 오류 발생:", error);
-        setProfile((prev) => ({
-          ...prev,
-          name: "데이터 로딩 오류",
-          gradeLabel: "N/A",
-        }));
+        console.error("데이터 로딩 중 오류 발생:", error);
       }
     };
 
-    loadProfile();
+    fetchData();
   }, []);
 
+  const mapApiToPostData = (apiPost, profileData) => {
+    return {
+      id: apiPost.postId,
+      title: apiPost.title,
+      content: apiPost.content,
+      languages: apiPost.languages
+        ? apiPost.languages.split(",").map((s) => s.trim())
+        : [],
+      stacks: apiPost.stacks
+        ? apiPost.stacks.split(",").map((s) => s.trim())
+        : [],
+      likes: apiPost.likesCount,
+      comments: apiPost.feedbackCount,
+      views: apiPost.views,
+      timeAgo: formatTimeAgo(apiPost.createdAt),
+      author: profileData.userName,
+      avatar: profileData.userPicture,
+      createdAt: apiPost.createdAt,
+    };
+  };
+
+  const handlePostClick = (postId) => {
+    navigate(`/posts/${postId}`);
+  };
+
+  // 게시글 더보기 버튼 클릭 시
+  const expandPosts = async () => {
+    // 아직 전체 데이터를 불러오지 않았고, 실제로 더 불러올 데이터가 있는 경우 (현재 개수 < 총 개수)
+    if (!hasFetchedAllPosts && myPosts.length < profile.postCount) {
+      try {
+        const res = await getUserPosts(currentUserId, 0, 100);
+        const allPostsMapped = res.data.content.map((post) =>
+          mapApiToPostData(post, profile)
+        );
+        setMyPosts(allPostsMapped);
+        setHasFetchedAllPosts(true);
+        setMyPostsDisplayCount(allPostsMapped.length);
+      } catch (e) {
+        console.error("전체 게시글 로딩 실패", e);
+      }
+    } else {
+      setMyPostsDisplayCount(myPosts.length);
+    }
+  };
+
+  const collapsePosts = () => {
+    setMyPostsDisplayCount(INITIAL_COUNT);
+    postsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const expandFeedback = () => setMyFeedbackCount(myFeedbackAll.length);
+  const collapseFeedback = () => {
+    setMyFeedbackCount(INITIAL_COUNT);
+    feedbackRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   const profileImgSrc = makeAbsoluteImageUrl(profile.avatar) || baseProfile;
+  const isPostsExpanded = myPostsDisplayCount >= profile.postCount; // 총 개수 기준
+  const isFeedbackExpanded = myFeedbackCount >= myFeedbackAll.length;
 
   const GradeDonut = ({ percent = 50, label = "등급" }) => {
     const size = 120;
@@ -103,39 +192,13 @@ function MyPaged() {
     );
   };
 
-  const myPostsAll = samplePosts;
-  const myFeedbackAll = samplePosts;
-
-  const INITIAL_COUNT = 4;
-  const [activeTab, setActiveTab] = useState("posts");
-  const [myPostsCount, setMyPostsCount] = useState(INITIAL_COUNT);
-  const [myFeedbackCount, setMyFeedbackCount] = useState(INITIAL_COUNT);
-
-  const postsRef = useRef(null);
-  const feedbackRef = useRef(null);
-
-  const isPostsExpanded = myPostsCount >= myPostsAll.length;
-  const isFeedbackExpanded = myFeedbackCount >= myFeedbackAll.length;
-
-  const expandPosts = () => setMyPostsCount(myPostsAll.length);
-  const collapsePosts = () => {
-    setMyPostsCount(INITIAL_COUNT);
-    postsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
-
-  const expandFeedback = () => setMyFeedbackCount(myFeedbackAll.length);
-  const collapseFeedback = () => {
-    setMyFeedbackCount(INITIAL_COUNT);
-    feedbackRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
-
   return (
     <div className="min-h-screen bg-[#F5F7FA]">
       <Header />
       <div className="mx-auto max-w-[1100px] px-4 py-8">
         <div className="rounded-[10px] border border-gray-200 bg-white px-10 py-5 shadow-sm">
+          {/* 프로필 */}
           <div className="flex items-center gap-5 px-20 mb-10">
-            {/* 프로필 */}
             <div className="h-full w-[132px] overflow-hidden rounded-[10px]">
               <img
                 src={profileImgSrc}
@@ -147,12 +210,7 @@ function MyPaged() {
                 }}
               />
             </div>
-
-            {/* 가운데 박스 */}
-            <div
-              className="flex-1 w-[825px] rounded-[10px] border border-[#ACACAC] bg-white
-                          pl-6 pr-3 py-4 flex items-center justify-between box-border overflow-hidden"
-            >
+            <div className="flex-1 w-[825px] rounded-[10px] border border-[#ACACAC] bg-white pl-6 pr-3 py-4 flex items-center justify-between box-border overflow-hidden">
               <div className="flex-1 min-w-0">
                 <h2 className="text-[22px] font-semibold mb-2">
                   {profile.name}
@@ -182,8 +240,6 @@ function MyPaged() {
                   />
                 </ul>
               </div>
-
-              {/* 등급 */}
               <div className="shrink-0 ml-16 mr-5">
                 <GradeDonut
                   percent={profile.selectRate}
@@ -197,26 +253,23 @@ function MyPaged() {
           <div className="flex gap-2 mb-5 px-1">
             <button
               onClick={() => setActiveTab("posts")}
-              className={`px-3 py-1.5 rounded-full text-sm border transition
-                ${
-                  activeTab === "posts"
-                    ? "bg-[#00B834] text-white border-[#00B834]"
-                    : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
-                }`}
+              className={`px-3 py-1.5 rounded-full text-sm border transition ${
+                activeTab === "posts"
+                  ? "bg-[#00B834] text-white border-[#00B834]"
+                  : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+              }`}
             >
-              내 게시글 ({myPostsAll.length})
+              내 게시글 ({profile.postCount})
             </button>
-
             <button
               onClick={() => setActiveTab("feedback")}
-              className={`px-3 py-1.5 rounded-full text-sm border transition
-                ${
-                  activeTab === "feedback"
-                    ? "bg-[#00B834] text-white border-[#00B834]"
-                    : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
-                }`}
+              className={`px-3 py-1.5 rounded-full text-sm border transition ${
+                activeTab === "feedback"
+                  ? "bg-[#00B834] text-white border-[#00B834]"
+                  : "bg-white text-gray-700 border-gray-200 hover:border-gray-300"
+              }`}
             >
-              내 피드백 ({myFeedbackAll.length})
+              내 피드백 ({profile.feedbackCount})
             </button>
           </div>
 
@@ -228,22 +281,28 @@ function MyPaged() {
                   내가 올린 게시글
                 </h2>
               </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {myPostsAll.slice(0, myPostsCount).map((p) => (
-                  <PostCard
-                    key={`mypost-${p.id}`}
-                    {...p}
-                    badge="내 게시글"
-                    rightPill={null}
-                    onClick={() => handlePostClick(p.id)}
-                  />
-                ))}
-              </div>
+              {myPosts.length === 0 ? (
+                <div className="text-center py-10 text-gray-500">
+                  등록된 게시글이 없습니다.
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {myPosts.slice(0, myPostsDisplayCount).map((p) => (
+                    <PostCard
+                      key={`mypost-${p.id}`}
+                      {...p}
+                      avatar={makeAbsoluteImageUrl(p.avatar) || baseProfile}
+                      badge="내 게시글"
+                      rightPill={null}
+                      onClick={() => handlePostClick(p.id)}
+                    />
+                  ))}
+                </div>
+              )}
 
               {/* 더보기/접기 버튼 */}
               <div className="mt-6 flex items-center justify-center gap-2">
-                {myPostsAll.length > INITIAL_COUNT && !isPostsExpanded && (
+                {profile.postCount > INITIAL_COUNT && !isPostsExpanded && (
                   <button
                     onClick={expandPosts}
                     className="px-4 py-2 text-sm rounded-md border border-[#00B834] text-[#00B834] hover:bg-[#00B834]/5"
@@ -251,7 +310,7 @@ function MyPaged() {
                     더보기
                   </button>
                 )}
-                {myPostsAll.length > INITIAL_COUNT && isPostsExpanded && (
+                {profile.postCount > INITIAL_COUNT && isPostsExpanded && (
                   <button
                     onClick={collapsePosts}
                     className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
@@ -284,7 +343,6 @@ function MyPaged() {
                 ))}
               </div>
 
-              {/* 더보기/접기 버튼 */}
               <div className="mt-6 flex items-center justify-center gap-2">
                 {myFeedbackAll.length > INITIAL_COUNT &&
                   !isFeedbackExpanded && (

--- a/src/pages/MyPaged.jsx
+++ b/src/pages/MyPaged.jsx
@@ -11,6 +11,7 @@ import {
   getUserRecentPosts,
   getUserPosts,
   getUserRecentFeedbacks,
+  getUserFeedbacks,
 } from "../api/userApi";
 import { makeAbsoluteImageUrl } from "../utils/imageHelper";
 
@@ -77,8 +78,8 @@ function MyPaged() {
           avatar: pData.userPicture,
           points: pData.points,
           selectRate: selectRate,
-          postCount: pData.postCount,
-          feedbackCount: pData.totalFeedbackCount,
+          postCount: pData.postCount, // 총 게시글 수
+          feedbackCount: pData.totalFeedbackCount, // 총 피드백 수
           gradeLabel: pData.grade,
         });
 
@@ -127,10 +128,9 @@ function MyPaged() {
 
   // 게시글 더보기 버튼 클릭 시 (전체/페이징 API 호출)
   const expandPosts = async () => {
-    // 아직 전체 데이터를 불러오지 않았고, 실제로 더 불러올 데이터가 있는 경우 (현재 개수 < 총 개수)
     if (!hasFetchedAllPosts) {
       try {
-        const res = await getUserPosts(currentUserId, 0, 100);
+        const res = await getUserPosts(currentUserId, 0, profile.postCount);
         const contentList = res.data.content || [];
 
         const allPostsMapped = contentList.map((post) =>
@@ -153,8 +153,26 @@ function MyPaged() {
     postsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  const expandFeedback = () => {
-    setMyFeedbackCount(myFeedbackAll.length);
+  // 피드백 더보기 버튼 클릭 시
+  const expandFeedback = async () => {
+    if (!hasFetchedAllFeedbacks) {
+      try {
+        const res = await getUserFeedbacks(
+          currentUserId,
+          0,
+          profile.feedbackCount
+        );
+        const contentList = res.data.content || [];
+
+        setMyFeedbackAll(contentList);
+        setHasFetchedAllFeedbacks(true);
+        setMyFeedbackCount(contentList.length);
+      } catch (e) {
+        console.error("전체 피드백 로딩 실패", e);
+      }
+    } else {
+      setMyFeedbackCount(myFeedbackAll.length);
+    }
   };
 
   const collapseFeedback = () => {
@@ -164,7 +182,7 @@ function MyPaged() {
 
   const profileImgSrc = makeAbsoluteImageUrl(profile.avatar) || baseProfile;
   const isPostsExpanded = myPostsDisplayCount >= profile.postCount;
-  const isFeedbackExpanded = myFeedbackCount >= myFeedbackAll.length;
+  const isFeedbackExpanded = myFeedbackCount >= profile.feedbackCount;
 
   const GradeDonut = ({ percent = 50, label = "등급" }) => {
     const size = 120;
@@ -322,6 +340,7 @@ function MyPaged() {
                     더보기
                   </button>
                 )}
+                {/* 전체 게시글이 표시되었을 때 */}
                 {profile.postCount > INITIAL_COUNT && isPostsExpanded && (
                   <button
                     onClick={collapsePosts}
@@ -363,7 +382,7 @@ function MyPaged() {
               )}
 
               <div className="mt-6 flex items-center justify-center gap-2">
-                {myFeedbackAll.length > INITIAL_COUNT &&
+                {profile.feedbackCount > INITIAL_COUNT &&
                   !isFeedbackExpanded && (
                     <button
                       onClick={expandFeedback}
@@ -372,14 +391,16 @@ function MyPaged() {
                       더보기
                     </button>
                   )}
-                {myFeedbackAll.length > INITIAL_COUNT && isFeedbackExpanded && (
-                  <button
-                    onClick={collapseFeedback}
-                    className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
-                  >
-                    접기
-                  </button>
-                )}
+                {/* 전체 피드백이 표시되었을 때 */}
+                {profile.feedbackCount > INITIAL_COUNT &&
+                  isFeedbackExpanded && (
+                    <button
+                      onClick={collapseFeedback}
+                      className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                    >
+                      접기
+                    </button>
+                  )}
               </div>
             </section>
           )}


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 마이페이지 API 연동

## 🔧 주요 변경 내용
<!-- 주요 변경사항들을 나열해주세요 -->
- 사용자 정보 조회 API 연동
  - 등급 : 새싹 개발자, 잎새 개발자, 나무 개발자, 숲의 현자 에 따라 도넛 모양 등급 채움 다르게
- 로그인 한 사용자가 자신의 마이페이지에 접속한 경우(`/my-paged`)
  - `내가 올린 게시글`, `내가 작성한 피드백`, `**내가 스크랩한 게시물**` 목록 조회
- 다른 사용자의 페이지에 접속한 경우(`/my-paged/{userId}`)
  - `{사용자 아이디} 님의 게시글`, `{사용자 아이디} 님의 피드백`  목록 조회
  - 스크랩 탭은 없음
- 피드백 목록 카드 구현
  - 채택 상태 여부에 따라 `채택 대기`, `채택 완료` 뱃지 디자인
- 프로필 사진 업로드 기능
- 프로필 사진 삭제 기능
- 게시글 or 피드백 카드가 5개 이상인 경우 `더보기` 버튼 노출

## 📸 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1578" height="1349" alt="localhost_3000_my-paged_1 (1)" src="https://github.com/user-attachments/assets/df702dd1-8236-4ca9-ac2a-bf1629cb0279" />
<img width="1578" height="1200" alt="localhost_3000_my-paged_3" src="https://github.com/user-attachments/assets/c589b56a-7123-4100-bedf-11e3e84f04a0" />