### PR TITLE
feat: 회원가입 아이디/이메일 중복확인 API 연동

### DIFF
--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -12,6 +12,13 @@ export const checkUsername = (userName) => {
   });
 };
 
+// 이메일 중복 확인
+export const checkEmail = (email) => {
+  return api.get("/api/user/check-email", {
+    params: { email },
+  });
+};
+
 // 로그인
 export const login = async (data) => {
   const res = await api.post("/api/user/login", data);

--- a/src/api/userApi.js
+++ b/src/api/userApi.js
@@ -5,6 +5,13 @@ export const signup = (data) => {
   return api.post("/api/user/signup", data);
 };
 
+// 아이디 중복 확인
+export const checkUsername = (userName) => {
+  return api.get("/api/user/check-username", {
+    params: { userName },
+  });
+};
+
 // 로그인
 export const login = async (data) => {
   const res = await api.post("/api/user/login", data);

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Header from "../components/header/Header";
+import HeaderAuth from "../components/header/HeaderAuth";
 import illustration from "../assets/illustration.png";
 import { login } from "../api/userApi";
 
@@ -36,7 +36,7 @@ function SignIn() {
 
   return (
     <div className="w-full h-screen bg-gradient-to-r from-[#F0FDF4] to-[#BDF7D1]">
-      <Header />
+      <HeaderAuth />
       <div className="flex justify-center">
         <div className="mt-20">
           <div className="text-[30px] font-semibold">

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Header from "../components/header/Header";
 import illustration from "../assets/illustration.png";
-import { signup, checkUsername } from "../api/userApi";
+import { signup, checkUsername, checkEmail } from "../api/userApi";
 
 function SignUp() {
   // 입력값 상태 관리
@@ -10,12 +10,17 @@ function SignUp() {
   const [password, setPassword] = useState("");
   const [passwordCheck, setPasswordCheck] = useState("");
 
-  // 아이디 중복 확인 관련 상태
-  const [isCheckingUsername, setIsCheckingUsername] = useState(false); // 로딩 여부
-  const [usernameCheckMessage, setUsernameCheckMessage] = useState(""); // 안내 메시지
-  const [isUsernameAvailable, setIsUsernameAvailable] = useState(null); // null | true | false
+  // 아이디 중복 확인 상태
+  const [isCheckingUsername, setIsCheckingUsername] = useState(false);
+  const [usernameCheckMessage, setUsernameCheckMessage] = useState("");
+  const [isUsernameAvailable, setIsUsernameAvailable] = useState(null);
 
-  // 아이디 중복 확인 함수
+  // 이메일 중복 확인 상태
+  const [isCheckingEmail, setIsCheckingEmail] = useState(false);
+  const [emailCheckMessage, setEmailCheckMessage] = useState("");
+  const [isEmailAvailable, setIsEmailAvailable] = useState(null);
+
+  // 아이디 중복 확인
   const handleCheckUsername = async () => {
     if (!userName.trim()) {
       setUsernameCheckMessage("아이디를 입력해 주세요.");
@@ -40,23 +45,59 @@ function SignUp() {
       }
     } catch (err) {
       console.error(err);
-      setUsernameCheckMessage("아이디 중복 확인 중 오류가 발생했습니다.");
+      setUsernameCheckMessage("아이디 확인 중 오류가 발생했습니다.");
       setIsUsernameAvailable(false);
     } finally {
       setIsCheckingUsername(false);
     }
   };
 
-  // 회원가입 처리 함수
+  // 이메일 중복 확인
+  const handleCheckEmail = async () => {
+    if (!email.trim()) {
+      setEmailCheckMessage("이메일을 입력해 주세요.");
+      setIsEmailAvailable(false);
+      return;
+    }
+
+    try {
+      setIsCheckingEmail(true);
+      setEmailCheckMessage("");
+      setIsEmailAvailable(null);
+
+      const res = await checkEmail(email);
+      const available = res.data === true;
+
+      if (available) {
+        setEmailCheckMessage("사용 가능한 이메일입니다.");
+        setIsEmailAvailable(true);
+      } else {
+        setEmailCheckMessage("이미 사용 중인 이메일입니다.");
+        setIsEmailAvailable(false);
+      }
+    } catch (err) {
+      console.error(err);
+      setEmailCheckMessage("이메일 확인 중 오류가 발생했습니다.");
+      setIsEmailAvailable(false);
+    } finally {
+      setIsCheckingEmail(false);
+    }
+  };
+
+  // 회원가입 처리
   const handleSignup = async () => {
     if (password !== passwordCheck) {
       alert("비밀번호가 일치하지 않습니다.");
       return;
     }
 
-    // 아이디 중복 확인하지 않고 회원가입 버튼을 누를 시
+    // 중복 확인 강제
     if (isUsernameAvailable !== true) {
       alert("아이디 중복 확인을 완료해 주세요.");
+      return;
+    }
+    if (isEmailAvailable !== true) {
+      alert("이메일 중복 확인을 완료해 주세요.");
       return;
     }
 
@@ -68,9 +109,6 @@ function SignUp() {
       });
 
       alert("회원가입 성공!");
-      console.log(res.data);
-
-      // 예: 회원가입 성공 후 로그인 페이지로 이동
       window.location.href = "/sign-in";
     } catch (err) {
       console.error(err);
@@ -103,39 +141,33 @@ function SignUp() {
             {/* 아이디 */}
             <div className="flex flex-col mb-4">
               <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
-                아이디
-                <p className="text-[#00C839]">*</p>
+                아이디 <p className="text-[#00C839]">*</p>
               </label>
               <div className="flex items-center gap-2">
                 <input
                   type="text"
                   placeholder="아이디를 입력해 주세요"
-                  className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                  className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px]"
                   value={userName}
                   onChange={(e) => {
                     setUserName(e.target.value);
-                    // 입력이 바뀌면 이전 검사 결과 초기화
                     setUsernameCheckMessage("");
                     setIsUsernameAvailable(null);
                   }}
                 />
                 <button
                   type="button"
-                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px] hover:bg-[#212121]"
+                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px]"
                   onClick={handleCheckUsername}
                   disabled={isCheckingUsername}
                 >
                   {isCheckingUsername ? "확인중" : "중복확인"}
                 </button>
               </div>
-
-              {/* 아이디 중복 확인 메시지 */}
               {usernameCheckMessage && (
                 <p
                   className={`mt-1 ml-1 text-[10px] ${
-                    isUsernameAvailable
-                      ? "text-[#00C839]" // 사용 가능
-                      : "text-[#FF4D4F]" // 중복
+                    isUsernameAvailable ? "text-[#00C839]" : "text-[#FF4D4F]"
                   }`}
                 >
                   {usernameCheckMessage}
@@ -146,38 +178,49 @@ function SignUp() {
             {/* 이메일 */}
             <div className="flex flex-col mb-4">
               <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
-                이메일
-                <p className="text-[#00C839]">*</p>
+                이메일 <p className="text-[#00C839]">*</p>
               </label>
               <div className="flex items-center gap-2">
                 <input
                   type="text"
                   placeholder="이메일을 입력해 주세요"
-                  className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                  className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px]"
                   value={email}
                   onChange={(e) => {
                     setEmail(e.target.value);
+                    setEmailCheckMessage("");
+                    setIsEmailAvailable(null);
                   }}
                 />
                 <button
                   type="button"
-                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px] hover:bg-[#212121]"
+                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px]"
+                  onClick={handleCheckEmail}
+                  disabled={isCheckingEmail}
                 >
-                  중복확인
+                  {isCheckingEmail ? "확인중" : "중복확인"}
                 </button>
               </div>
+              {emailCheckMessage && (
+                <p
+                  className={`mt-1 ml-1 text-[10px] ${
+                    isEmailAvailable ? "text-[#00C839]" : "text-[#FF4D4F]"
+                  }`}
+                >
+                  {emailCheckMessage}
+                </p>
+              )}
             </div>
 
             {/* 비밀번호 */}
             <div className="flex flex-col mb-3">
               <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
-                비밀번호
-                <p className="text-[#00C839]">*</p>
+                비밀번호 <p className="text-[#00C839]">*</p>
               </label>
               <input
                 type="password"
                 placeholder="영문자, 숫자 포함 8~12자"
-                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px]"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
               />
@@ -188,7 +231,7 @@ function SignUp() {
               <input
                 type="password"
                 placeholder="비밀번호를 확인해주세요"
-                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px]"
                 value={passwordCheck}
                 onChange={(e) => setPasswordCheck(e.target.value)}
               />
@@ -196,13 +239,13 @@ function SignUp() {
 
             {/* 회원가입 버튼 */}
             <button
-              className="w-[160px] h-[40px] bg-[#00C839] text-white text-[16px] py-2 rounded-[6px] font-medium hover:bg-[#0bdd47]"
+              className="w-[160px] h-[40px] bg-[#00C839] text-white text-[16px] py-2 rounded-[6px]"
               onClick={handleSignup}
             >
               회원가입
             </button>
 
-            {/* 로그인 이동 링크 */}
+            {/* 로그인 이동 */}
             <p className="text-[10px] text-[#B8B8B8] mt-4">
               이미 계정이 있으신가요?{" "}
               <a

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Header from "../components/header/Header";
+import HeaderAuth from "../components/header/HeaderAuth";
 import illustration from "../assets/illustration.png";
 import { signup, checkUsername, checkEmail } from "../api/userApi";
 
@@ -118,7 +118,7 @@ function SignUp() {
 
   return (
     <div className="w-full h-screen bg-gradient-to-r from-[#F0FDF4] to-[#BDF7D1]">
-      <Header />
+      <HeaderAuth />
       <div className="flex justify-center">
         <div className="mt-20">
           <div className="text-[30px] font-semibold">

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,20 +1,62 @@
 import React, { useState } from "react";
 import Header from "../components/header/Header";
 import illustration from "../assets/illustration.png";
-import { signup } from '../api/userApi';
+import { signup, checkUsername } from "../api/userApi";
 
 function SignUp() {
-
-  // ⭐ 입력값 상태 관리
+  // 입력값 상태 관리
   const [userName, setUserName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [passwordCheck, setPasswordCheck] = useState("");
 
-  // ⭐ 회원가입 처리 함수
+  // 아이디 중복 확인 관련 상태
+  const [isCheckingUsername, setIsCheckingUsername] = useState(false); // 로딩 여부
+  const [usernameCheckMessage, setUsernameCheckMessage] = useState(""); // 안내 메시지
+  const [isUsernameAvailable, setIsUsernameAvailable] = useState(null); // null | true | false
+
+  // 아이디 중복 확인 함수
+  const handleCheckUsername = async () => {
+    if (!userName.trim()) {
+      setUsernameCheckMessage("아이디를 입력해 주세요.");
+      setIsUsernameAvailable(false);
+      return;
+    }
+
+    try {
+      setIsCheckingUsername(true);
+      setUsernameCheckMessage("");
+      setIsUsernameAvailable(null);
+
+      const res = await checkUsername(userName);
+      const available = res.data === true;
+
+      if (available) {
+        setUsernameCheckMessage("사용 가능한 아이디입니다.");
+        setIsUsernameAvailable(true);
+      } else {
+        setUsernameCheckMessage("이미 사용 중인 아이디입니다.");
+        setIsUsernameAvailable(false);
+      }
+    } catch (err) {
+      console.error(err);
+      setUsernameCheckMessage("아이디 중복 확인 중 오류가 발생했습니다.");
+      setIsUsernameAvailable(false);
+    } finally {
+      setIsCheckingUsername(false);
+    }
+  };
+
+  // 회원가입 처리 함수
   const handleSignup = async () => {
     if (password !== passwordCheck) {
       alert("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    // 아이디 중복 확인하지 않고 회원가입 버튼을 누를 시
+    if (isUsernameAvailable !== true) {
+      alert("아이디 중복 확인을 완료해 주세요.");
       return;
     }
 
@@ -22,7 +64,7 @@ function SignUp() {
       const res = await signup({
         userName,
         email,
-        password
+        password,
       });
 
       alert("회원가입 성공!");
@@ -30,7 +72,6 @@ function SignUp() {
 
       // 예: 회원가입 성공 후 로그인 페이지로 이동
       window.location.href = "/sign-in";
-
     } catch (err) {
       console.error(err);
       alert("회원가입 실패");
@@ -38,122 +79,143 @@ function SignUp() {
   };
 
   return (
-      <div className="w-full h-screen bg-gradient-to-r from-[#F0FDF4] to-[#BDF7D1]">
-        <Header />
-        <div className="flex justify-center">
-          <div className="mt-20">
-            <div className="text-[30px] font-semibold">
-              <h3 className="text-[#4D4D4D]">
-                안녕하세요, 코드와 피드백이 자라는 정원
-              </h3>
-              <span className="text-[#00C839]">Code Gardener</span>
-              <span className="text-[#4D4D4D]">입니다.</span>
-            </div>
-            <img
-                src={illustration}
-                alt="illust"
-                className="w-[673px] h-[449px]"
-            />
+    <div className="w-full h-screen bg-gradient-to-r from-[#F0FDF4] to-[#BDF7D1]">
+      <Header />
+      <div className="flex justify-center">
+        <div className="mt-20">
+          <div className="text-[30px] font-semibold">
+            <h3 className="text-[#4D4D4D]">
+              안녕하세요, 코드와 피드백이 자라는 정원
+            </h3>
+            <span className="text-[#00C839]">Code Gardener</span>
+            <span className="text-[#4D4D4D]">입니다.</span>
           </div>
+          <img
+            src={illustration}
+            alt="illust"
+            className="w-[673px] h-[449px]"
+          />
+        </div>
 
-          <div className="flex flex-col items-center w-[499px] h-[562px] bg-white rounded-[16px] border border-[#B8B8B8] mt-12">
-            <h2 className="text-[30px] font-semibold mt-16 mb-6">회원가입</h2>
-            <div className="flex flex-col items-center">
-
-              {/* 아이디 */}
-              <div className="flex flex-col mb-4">
-                <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
-                  아이디
-                  <p className="text-[#00C839]">*</p>
-                </label>
-                <div className="flex items-center gap-2">
-                  <input
-                      type="text"
-                      placeholder="아이디를 입력해 주세요"
-                      className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
-                      value={userName}
-                      onChange={(e) => setUserName(e.target.value)}
-                  />
-                  <button
-                      type="button"
-                      className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px] hover:bg-[#212121]"
-                  >
-                    중복확인
-                  </button>
-                </div>
-              </div>
-
-              {/* 이메일 */}
-              <div className="flex flex-col mb-4">
-                <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
-                  이메일
-                  <p className="text-[#00C839]">*</p>
-                </label>
-                <div className="flex items-center gap-2">
-                  <input
-                      type="text"
-                      placeholder="이메일을 입력해 주세요"
-                      className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                  />
-                  <button
-                      type="button"
-                      className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px] hover:bg-[#212121]"
-                  >
-                    중복확인
-                  </button>
-                </div>
-              </div>
-
-              {/* 비밀번호 */}
-              <div className="flex flex-col mb-3">
-                <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
-                  비밀번호
-                  <p className="text-[#00C839]">*</p>
-                </label>
+        <div className="flex flex-col items-center w-[499px] h-[562px] bg-white rounded-[16px] border border-[#B8B8B8] mt-12">
+          <h2 className="text-[30px] font-semibold mt-16 mb-6">회원가입</h2>
+          <div className="flex flex-col items-center">
+            {/* 아이디 */}
+            <div className="flex flex-col mb-4">
+              <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
+                아이디
+                <p className="text-[#00C839]">*</p>
+              </label>
+              <div className="flex items-center gap-2">
                 <input
-                    type="password"
-                    placeholder="영문자, 숫자 포함 8~12자"
-                    className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                  type="text"
+                  placeholder="아이디를 입력해 주세요"
+                  className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                  value={userName}
+                  onChange={(e) => {
+                    setUserName(e.target.value);
+                    // 입력이 바뀌면 이전 검사 결과 초기화
+                    setUsernameCheckMessage("");
+                    setIsUsernameAvailable(null);
+                  }}
                 />
-              </div>
-
-              {/* 비밀번호 확인 */}
-              <div className="flex flex-col mb-7">
-                <input
-                    type="password"
-                    placeholder="비밀번호를 확인해주세요"
-                    className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
-                    value={passwordCheck}
-                    onChange={(e) => setPasswordCheck(e.target.value)}
-                />
-              </div>
-
-              {/* 회원가입 버튼 */}
-              <button
-                  className="w-[160px] h-[40px] bg-[#00C839] text-white text-[16px] py-2 rounded-[6px] font-medium hover:bg-[#0bdd47]"
-                  onClick={handleSignup}   // ⭐ 여기서 signup API 호출
-              >
-                회원가입
-              </button>
-
-              {/* 로그인 이동 링크 */}
-              <p className="text-[10px] text-[#B8B8B8] mt-4">
-                이미 계정이 있으신가요?{" "}
-                <a
-                    href="/sign-in"
-                    className="text-[#00C839] font-semibold hover:underline"
+                <button
+                  type="button"
+                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px] hover:bg-[#212121]"
+                  onClick={handleCheckUsername}
+                  disabled={isCheckingUsername}
                 >
-                  로그인
-                </a>
-              </p>
+                  {isCheckingUsername ? "확인중" : "중복확인"}
+                </button>
+              </div>
+
+              {/* 아이디 중복 확인 메시지 */}
+              {usernameCheckMessage && (
+                <p
+                  className={`mt-1 ml-1 text-[10px] ${
+                    isUsernameAvailable
+                      ? "text-[#00C839]" // 사용 가능
+                      : "text-[#FF4D4F]" // 중복
+                  }`}
+                >
+                  {usernameCheckMessage}
+                </p>
+              )}
             </div>
+
+            {/* 이메일 */}
+            <div className="flex flex-col mb-4">
+              <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
+                이메일
+                <p className="text-[#00C839]">*</p>
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  placeholder="이메일을 입력해 주세요"
+                  className="w-[280px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                  }}
+                />
+                <button
+                  type="button"
+                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px] hover:bg-[#212121]"
+                >
+                  중복확인
+                </button>
+              </div>
+            </div>
+
+            {/* 비밀번호 */}
+            <div className="flex flex-col mb-3">
+              <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
+                비밀번호
+                <p className="text-[#00C839]">*</p>
+              </label>
+              <input
+                type="password"
+                placeholder="영문자, 숫자 포함 8~12자"
+                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+
+            {/* 비밀번호 확인 */}
+            <div className="flex flex-col mb-7">
+              <input
+                type="password"
+                placeholder="비밀번호를 확인해주세요"
+                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] focus:outline-none placeholder:text-[#B8B8B8]"
+                value={passwordCheck}
+                onChange={(e) => setPasswordCheck(e.target.value)}
+              />
+            </div>
+
+            {/* 회원가입 버튼 */}
+            <button
+              className="w-[160px] h-[40px] bg-[#00C839] text-white text-[16px] py-2 rounded-[6px] font-medium hover:bg-[#0bdd47]"
+              onClick={handleSignup}
+            >
+              회원가입
+            </button>
+
+            {/* 로그인 이동 링크 */}
+            <p className="text-[10px] text-[#B8B8B8] mt-4">
+              이미 계정이 있으신가요?{" "}
+              <a
+                href="/sign-in"
+                className="text-[#00C839] font-semibold hover:underline"
+              >
+                로그인
+              </a>
+            </p>
           </div>
         </div>
       </div>
+    </div>
   );
 }
 

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -157,9 +157,11 @@ function SignUp() {
                 />
                 <button
                   type="button"
-                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px]"
+                  className="w-[69px] h-[40px] rounded-[6px] 
+             bg-[#4D4D4D] text-white text-[12px]
+             disabled:bg-[#CFCFCF] disabled:cursor-not-allowed"
                   onClick={handleCheckUsername}
-                  disabled={isCheckingUsername}
+                  disabled={isCheckingUsername || isUsernameAvailable === true}
                 >
                   {isCheckingUsername ? "확인중" : "중복확인"}
                 </button>
@@ -194,9 +196,11 @@ function SignUp() {
                 />
                 <button
                   type="button"
-                  className="w-[69px] h-[40px] rounded-[6px] bg-[#4D4D4D] text-white text-[12px]"
+                  className="w-[69px] h-[40px] rounded-[6px] 
+             bg-[#4D4D4D] text-white text-[12px]
+             disabled:bg-[#CFCFCF] disabled:cursor-not-allowed"
                   onClick={handleCheckEmail}
-                  disabled={isCheckingEmail}
+                  disabled={isCheckingEmail || isEmailAvailable === true}
                 >
                   {isCheckingEmail ? "확인중" : "중복확인"}
                 </button>

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import HeaderAuth from "../components/header/HeaderAuth";
 import illustration from "../assets/illustration.png";
 import { signup, checkUsername, checkEmail } from "../api/userApi";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 
 function SignUp() {
   // 입력값 상태 관리
@@ -19,6 +20,9 @@ function SignUp() {
   const [isCheckingEmail, setIsCheckingEmail] = useState(false);
   const [emailCheckMessage, setEmailCheckMessage] = useState("");
   const [isEmailAvailable, setIsEmailAvailable] = useState(null);
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordCheck, setShowPasswordCheck] = useState(false);
 
   // 아이디 중복 확인
   const handleCheckUsername = async () => {
@@ -221,24 +225,45 @@ function SignUp() {
               <label className="flex items-center text-[12px] font-medium text-[#4D4D4D] ml-1 mb-1">
                 비밀번호 <p className="text-[#00C839]">*</p>
               </label>
-              <input
-                type="password"
-                placeholder="영문자, 숫자 포함 8~12자"
-                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px]"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
+
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  placeholder="영문자, 숫자 포함 8~12자"
+                  className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] pr-10"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+
+                <button
+                  type="button"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#4D4D4D]"
+                  onClick={() => setShowPassword((prev) => !prev)}
+                >
+                  {showPassword ? <FaEye /> : <FaEyeSlash />}
+                </button>
+              </div>
             </div>
 
             {/* 비밀번호 확인 */}
             <div className="flex flex-col mb-7">
-              <input
-                type="password"
-                placeholder="비밀번호를 확인해주세요"
-                className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px]"
-                value={passwordCheck}
-                onChange={(e) => setPasswordCheck(e.target.value)}
-              />
+              <div className="relative">
+                <input
+                  type={showPasswordCheck ? "text" : "password"}
+                  placeholder="비밀번호를 확인해주세요"
+                  className="w-[360px] h-[40px] border border-[#B8B8B8] rounded-[6px] px-4 py-3 text-[12px] pr-10"
+                  value={passwordCheck}
+                  onChange={(e) => setPasswordCheck(e.target.value)}
+                />
+
+                <button
+                  type="button"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#4D4D4D]"
+                  onClick={() => setShowPasswordCheck((prev) => !prev)}
+                >
+                  {showPasswordCheck ? <FaEye /> : <FaEyeSlash />}
+                </button>
+              </div>
             </div>
 
             {/* 회원가입 버튼 */}


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 회원가입시 아이디, 이메일 중복 확인 API 연동
- 로그인/회원가입 전용 헤더 적용

## 🔧 주요 변경 내용
<!-- 주요 변경사항들을 나열해주세요 -->
- 아이디 or 이메일 중복 확인 검사를 하지 않고 회원가입 버튼을 클릭하는 경우 중복 확인이 필요하다는 알림창
- 중복 확인 완료 후에는 중복 확인 버튼 비활성화

## 📸 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1905" height="922" alt="image" src="https://github.com/user-attachments/assets/79aa241a-a0ec-4877-b34a-f836c41a03fa" />