### PR TITLE
feat: 리더보드 페이지 API 연동

### DIFF
--- a/src/api/leaderboardApi.js
+++ b/src/api/leaderboardApi.js
@@ -25,3 +25,9 @@ export const getFullLeaders = async (
   });
   return response.data;
 };
+
+// 이번 주 피드백 수 조회
+export async function getWeeklyFeedbackCount() {
+  const res = await api.get("api/feedback/week");
+  return res.data;
+}

--- a/src/api/leaderboardApi.js
+++ b/src/api/leaderboardApi.js
@@ -9,3 +9,19 @@ export const getTop3Leaders = async (criteria = "points") => {
   });
   return response.data;
 };
+
+// 리더보드 전체 목록 조회 (페이징 포함)
+export const getFullLeaders = async (
+  criteria = "points",
+  page = 0,
+  size = 20
+) => {
+  const response = await api.get("/api/leaderboard", {
+    params: {
+      sortBy: criteria,
+      page: page,
+      size: size,
+    },
+  });
+  return response.data;
+};

--- a/src/api/leaderboardApi.js
+++ b/src/api/leaderboardApi.js
@@ -26,8 +26,8 @@ export const getFullLeaders = async (
   return response.data;
 };
 
-// 이번 주 피드백 수 조회
-export async function getWeeklyFeedbackCount() {
-  const res = await api.get("api/feedback/week");
+// 이번 주 통계(신규 유저/게시글/피드백 수) 조회
+export async function getWeeklyStats() {
+  const res = await api.get("/api/leaderboard/weekly-stats");
   return res.data;
 }

--- a/src/api/leaderboardApi.js
+++ b/src/api/leaderboardApi.js
@@ -1,0 +1,11 @@
+import api from "./axios";
+
+// 리더보드 TOP 3 사용자 목록 조회
+export const getTop3Leaders = async (criteria = "points") => {
+  const response = await api.get("/api/leaderboard/top3", {
+    params: {
+      sortBy: criteria,
+    },
+  });
+  return response.data;
+};

--- a/src/components/leaderboard/LeaderboardTabs.jsx
+++ b/src/components/leaderboard/LeaderboardTabs.jsx
@@ -1,9 +1,23 @@
-import React, { useState } from "react";
+import React from "react";
 
-// 리더보드 정렬 탭 컴포넌트
-function LeaderboardTabs() {
-  const TABS = ["누적 포인트", "주간 피드백 채택 수", "주간 피드백 등록 수"];
-  const [active, setActive] = useState(TABS[0]);
+const CRITERIA_MAP = {
+  "누적 포인트": "points",
+  "주간 피드백 채택 수": "weeklyadopted",
+  "주간 피드백 등록 수": "weeklyfeedback",
+};
+const TABS = Object.keys(CRITERIA_MAP);
+
+function LeaderboardTabs({ currentCriteria, onCriteriaChange }) {
+  const handleClick = (tabName) => {
+    const criteria = CRITERIA_MAP[tabName];
+    if (onCriteriaChange && criteria) {
+      onCriteriaChange(criteria);
+    }
+  };
+
+  const activeTabName = TABS.find(
+    (name) => CRITERIA_MAP[name] === currentCriteria
+  );
 
   return (
     <div className="mt-8 w-full bg-white rounded-[10px] p-2 shadow-sm border border-[#E5E7EB]">
@@ -12,10 +26,10 @@ function LeaderboardTabs() {
           {TABS.map((tab) => (
             <button
               key={tab}
-              onClick={() => setActive(tab)}
+              onClick={() => handleClick(tab)}
               className={[
                 "h-10 rounded-[10px] text-[14px] font-medium transition-all",
-                active === tab
+                activeTabName === tab
                   ? "bg-white"
                   : "bg-transparent text-[#4D4D4D] hover:bg-[#eeeff0]",
               ].join(" ")}

--- a/src/components/leaderboard/RankingBoard.jsx
+++ b/src/components/leaderboard/RankingBoard.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TbCoin } from "react-icons/tb";
+import { useNavigate } from "react-router-dom";
 import profile from "../../assets/baseProfile.png";
 import { makeAbsoluteImageUrl } from "../../utils/imageHelper";
 
@@ -27,6 +28,8 @@ function RankingBoard({
   onLoadMore,
   onCollapse,
 }) {
+  const navigate = useNavigate();
+
   const DEFAULT_DISPLAY_COUNT = 7;
   const top3Leaders = leaders.slice(0, 3);
   const first = top3Leaders[0];
@@ -50,6 +53,7 @@ function RankingBoard({
     profileImage,
     grade,
     tone = "neutral",
+    userId,
   }) => {
     const displayScore = score || 0;
     const absoluteImageUrl = profileImage
@@ -60,11 +64,13 @@ function RankingBoard({
       gold: "bg-[#FEF9C3] border-[#FACC15]",
       silver: "bg-[#F3F4F6] border-[#D1D5DB]",
       bronze: "bg-[#FFE4D6] border-[#FDBA74]",
+      neutral: "bg-white border-[#E5E7EB]",
     };
 
     return (
       <div
-        className={`w-[280px] h-[220px] p-6 flex flex-col items-center justify-center rounded-2xl shadow-sm border ${toneMap[tone]}`}
+        className={`w-[280px] h-[220px] p-6 flex flex-col items-center justify-center rounded-2xl shadow-sm border cursor-pointer ${toneMap[tone]}`}
+        onClick={() => navigate(`/my-paged/${userId}`)}
       >
         {/* 등수 배지 */}
         <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/70 text-[13px] font-bold border border-black/10">
@@ -93,7 +99,7 @@ function RankingBoard({
   };
 
   // 4위 이하 일반 리스트용 카드
-  const RowCard = ({ rank, name, score, profileImage, grade }) => {
+  const RowCard = ({ rank, name, score, profileImage, grade, userId }) => {
     const absoluteImageUrl = profileImage
       ? makeAbsoluteImageUrl(profileImage)
       : profile;
@@ -102,7 +108,10 @@ function RankingBoard({
     const badgeStyle = getGradeBadgeStyle(grade);
 
     return (
-      <div className="flex items-center justify-between w-full px-10 py-4 rounded-xl bg-white border border-[#E5E7EB] shadow-sm">
+      <div
+        className="flex items-center justify-between w-full px-10 py-4 rounded-xl bg-white border border-[#E5E7EB] shadow-sm cursor-pointer hover:bg-[#F9FAFB] transition"
+        onClick={() => navigate(`/my-paged/${userId}`)}
+      >
         {/* 왼쪽 영역 */}
         <div className="flex items-center gap-4">
           <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[#F3F4F6] text-[#374151] text-[13px] font-bold">
@@ -178,6 +187,7 @@ function RankingBoard({
                 profileImage={second.userPicture}
                 grade={second.grade}
                 tone="silver"
+                userId={second.userId}
               />
             )}
           </div>
@@ -194,6 +204,7 @@ function RankingBoard({
                 profileImage={first.userPicture}
                 grade={first.grade}
                 tone="gold"
+                userId={first.userId}
               />
             )}
           </div>
@@ -210,6 +221,7 @@ function RankingBoard({
                 profileImage={third.userPicture}
                 grade={third.grade}
                 tone="bronze"
+                userId={third.userId}
               />
             )}
           </div>
@@ -239,6 +251,7 @@ function RankingBoard({
               }
               profileImage={item.userPicture}
               grade={item.grade}
+              userId={item.userId}
             />
           ))}
           {loading && (

--- a/src/components/leaderboard/RankingBoard.jsx
+++ b/src/components/leaderboard/RankingBoard.jsx
@@ -1,45 +1,31 @@
 import React, { useMemo, useState } from "react";
-import samplePosts from "../postcontext.jsx";
 import { TbCoin } from "react-icons/tb";
 import profile from "../../assets/baseProfile.png";
 import { makeAbsoluteImageUrl } from "../../utils/imageHelper";
-function rankByPoints(posts) {
-  return [...posts]
-    .sort((a, b) => b.points - a.points)
-    .map((post, idx) => ({
-      rank: idx + 1,
-      name: post.author,
-      score: post.points,
-      profileImage: profile,
-    }));
-}
 
-function RankingBoard({ leaders, loading }) {
-  const fullMockedRanked = useMemo(() => rankByPoints(samplePosts), []);
-
-  const DEFAULT_COUNT = 10; // 기본 표시 인원
-  const MAX_EXPANDED = 50; // 더보기로 펼칠 수 있는 최대 인원
-
-  // 전체 순위에서 표시할 총 인원(Top3 포함)
-  const [showCount, setShowCount] = useState(DEFAULT_COUNT);
-
-  // 상단 Top3 데이터
+function RankingBoard({
+  leaders,
+  loading,
+  fullLeaders,
+  totalElements,
+  isLast,
+  onLoadMore,
+  onCollapse,
+}) {
+  const DEFAULT_DISPLAY_COUNT = 7;
   const top3Leaders = leaders.slice(0, 3);
   const first = top3Leaders[0];
   const second = top3Leaders[1];
   const third = top3Leaders[2];
+  const rest = fullLeaders;
 
-  // 목록 데이터
-  const rest = fullMockedRanked.slice(
-    3,
-    Math.min(showCount, fullMockedRanked.length)
-  );
-
-  const maxShowable = Math.min(fullMockedRanked.length, MAX_EXPANDED);
-  const isAtDefault = showCount === DEFAULT_COUNT;
-  const isAtMax = showCount >= maxShowable;
-  const handleMore = () => setShowCount(maxShowable);
-  const handleCollapse = () => setShowCount(DEFAULT_COUNT);
+  // 현재 전체 순위 리스트에 표시된 항목의 총 수 (Top 3 제외)
+  const currentDisplayedCount = rest.length;
+  // API의 전체 항목 수
+  const maxTotalCount = totalElements;
+  const isExpanded = currentDisplayedCount > DEFAULT_DISPLAY_COUNT;
+  const isAtMax = isLast; // 마지막 페이지이면 더보기 버튼 비활성화
+  const isAtDefault = !isExpanded; // 기본 개수라면 접기 버튼 비활성화
 
   // 상단 Top 3 전용 카드
   const TopCard = ({
@@ -135,7 +121,7 @@ function RankingBoard({ leaders, loading }) {
     );
   };
 
-  if (loading) {
+  if (loading && top3Leaders.length === 0) {
     return (
       <div className="mt-12 text-center text-[#6B7280]">
         <p>데이터를 불러오는 중입니다...</p>
@@ -143,7 +129,7 @@ function RankingBoard({ leaders, loading }) {
     );
   }
 
-  if (top3Leaders.length === 0 && fullMockedRanked.length === 0) {
+  if (top3Leaders.length === 0 && maxTotalCount === 0) {
     return (
       <div className="mt-12 text-center text-[#6B7280]">
         <p>😭 아직 리더보드 데이터가 없습니다.</p>
@@ -217,17 +203,37 @@ function RankingBoard({ leaders, loading }) {
         <div className="flex items-center justify-between px-5 py-3 border-b border-[#E5E7EB]">
           <div className="text-[13px] text-[#111827]">전체 순위</div>
           <div className="text-[12px] text-[#6B7280]">
-            {/* 목업 데이터 전체 길이를 사용 */}
-            {fullMockedRanked.length}명 중 {Math.min(showCount, maxShowable)}명
-            표시
+            {maxTotalCount}명 중{" "}
+            {Math.min(maxTotalCount, 3 + currentDisplayedCount)}명 표시
           </div>
         </div>
 
         {/* 리스트 */}
         <div className="p-4 space-y-3">
-          {rest.map((item) => (
-            <RowCard key={item.rank} {...item} />
+          {rest.map((item, index) => (
+            <RowCard
+              key={item.userId}
+              rank={index + 4} // 4위부터 시작
+              name={item.userName}
+              score={
+                item.points ||
+                item.adoptedFeedbackCount ||
+                item.totalFeedbackCount
+              }
+              profileImage={item.userPicture}
+            />
           ))}
+          {loading && (
+            <p className="text-center text-[#9CA3AF] py-4">
+              다음 순위 목록을 불러오는 중입니다...
+            </p>
+          )}
+
+          {maxTotalCount > 0 && currentDisplayedCount === 0 && !loading && (
+            <p className="text-center text-[#9CA3AF] py-4">
+              4위 이하 목록이 현재 순위 기준에 없습니다.
+            </p>
+          )}
         </div>
 
         {/* 더보기 / 접기 버튼 */}
@@ -236,11 +242,11 @@ function RankingBoard({ leaders, loading }) {
             {/* 더보기 */}
             <button
               type="button"
-              onClick={handleMore}
-              disabled={isAtMax}
+              onClick={onLoadMore}
+              disabled={isAtMax || loading}
               className={`w-full px-4 py-2 rounded-lg border text-[13px] transition
                 ${
-                  isAtMax
+                  isAtMax || loading
                     ? "bg-[#F3F4F6] border-[#E5E7EB] text-[#9CA3AF] cursor-not-allowed"
                     : "bg-white border-[#D1D5DB] text-[#111827] hover:bg-[#F9FAFB]"
                 }`}
@@ -251,7 +257,7 @@ function RankingBoard({ leaders, loading }) {
             {/* 접기 */}
             <button
               type="button"
-              onClick={handleCollapse}
+              onClick={onCollapse}
               disabled={isAtDefault}
               className={`w-full px-4 py-2 rounded-lg border text-[13px] transition
                 ${

--- a/src/components/leaderboard/RankingBoard.jsx
+++ b/src/components/leaderboard/RankingBoard.jsx
@@ -93,7 +93,7 @@ function RankingBoard({
   };
 
   // 4위 이하 일반 리스트용 카드
-  const RowCard = ({ rank, name, score, profileImage }) => {
+  const RowCard = ({ rank, name, score, profileImage, grade }) => {
     const absoluteImageUrl = profileImage
       ? makeAbsoluteImageUrl(profileImage)
       : profile;

--- a/src/components/leaderboard/RankingBoard.jsx
+++ b/src/components/leaderboard/RankingBoard.jsx
@@ -1,7 +1,22 @@
-import React, { useMemo, useState } from "react";
+import React from "react";
 import { TbCoin } from "react-icons/tb";
 import profile from "../../assets/baseProfile.png";
 import { makeAbsoluteImageUrl } from "../../utils/imageHelper";
+
+// 등급별 배지 스타일 매핑 함수
+const getGradeBadgeStyle = (grade) => {
+  switch (grade) {
+    case "숲의 현자":
+      return "bg-[#DBEAFE] text-[#193CB8]";
+    case "나무 개발자":
+      return "bg-[#FEF3C7] text-[#92400E]";
+    case "잎새 개발자":
+      return "bg-[#D1FAE5] text-[#065F46]";
+    case "새싹 개발자":
+    default:
+      return "bg-[#ECFCCB] text-[#4D7C0F]";
+  }
+};
 
 function RankingBoard({
   leaders,
@@ -42,9 +57,9 @@ function RankingBoard({
       : profile;
 
     const toneMap = {
-      gold: "bg-[#FEF9C3] border-[#FACC15]", // 1등
-      silver: "bg-[#F3F4F6] border-[#D1D5DB]", // 2등
-      bronze: "bg-[#FFE4D6] border-[#FDBA74]", // 3등
+      gold: "bg-[#FEF9C3] border-[#FACC15]",
+      silver: "bg-[#F3F4F6] border-[#D1D5DB]",
+      bronze: "bg-[#FFE4D6] border-[#FDBA74]",
     };
 
     return (
@@ -66,7 +81,6 @@ function RankingBoard({
           />
         </div>
 
-        {/* 이름 + 포인트 */}
         <div className="mt-4 text-center">
           <div className="text-[16px] font-semibold">{name}</div>
           <div className="flex items-center justify-center gap-1 text-[14px] text-[#4D4D4D] mt-1">
@@ -84,16 +98,17 @@ function RankingBoard({
       ? makeAbsoluteImageUrl(profileImage)
       : profile;
 
+    // grade가 없거나 이상한 값이면 '새싹 개발자' 스타일 적용 (default case)
+    const badgeStyle = getGradeBadgeStyle(grade);
+
     return (
       <div className="flex items-center justify-between w-full px-10 py-4 rounded-xl bg-white border border-[#E5E7EB] shadow-sm">
         {/* 왼쪽 영역 */}
         <div className="flex items-center gap-4">
-          {/* 등수 배지 */}
           <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[#F3F4F6] text-[#374151] text-[13px] font-bold">
             {rank}
           </span>
 
-          {/* 프로필 이미지 + 이름 */}
           <div className="flex items-center gap-3">
             <div className="w-8 h-8 rounded-full bg-[#F9FAFB] border border-[#E5E7EB] overflow-hidden">
               <img
@@ -106,10 +121,14 @@ function RankingBoard({
             <div className="text-[15px] font-semibold">{name}</div>
           </div>
 
-          {/* 등급 배지 -> 추후 연동 */}
-          <span className="text-[11px] px-2 py-[2px] rounded-full bg-[#DBEAFE] text-[#193CB8]">
-            숲의 현자
-          </span>
+          {/* 등급 배지 */}
+          {grade && (
+            <span
+              className={`text-[11px] px-2 py-[2px] rounded-full ${badgeStyle}`}
+            >
+              {grade}
+            </span>
+          )}
         </div>
 
         {/* 오른쪽 영역: 포인트 */}
@@ -147,7 +166,6 @@ function RankingBoard({
 
         <div className="flex items-end justify-center gap-4">
           <div className="translate-y-2">
-            {/* 2위: API 데이터 사용 */}
             {second && (
               <TopCard
                 rank={2}
@@ -158,12 +176,12 @@ function RankingBoard({
                   second.totalFeedbackCount
                 }
                 profileImage={second.userPicture}
+                grade={second.grade}
                 tone="silver"
               />
             )}
           </div>
           <div className="-translate-y-2">
-            {/* 1위: API 데이터 사용 */}
             {first && (
               <TopCard
                 rank={1}
@@ -174,12 +192,12 @@ function RankingBoard({
                   first.totalFeedbackCount
                 }
                 profileImage={first.userPicture}
+                grade={first.grade}
                 tone="gold"
               />
             )}
           </div>
           <div className="translate-y-2">
-            {/* 3위: API 데이터 사용 */}
             {third && (
               <TopCard
                 rank={3}
@@ -190,6 +208,7 @@ function RankingBoard({
                   third.totalFeedbackCount
                 }
                 profileImage={third.userPicture}
+                grade={third.grade}
                 tone="bronze"
               />
             )}
@@ -199,7 +218,6 @@ function RankingBoard({
 
       {/* 전체 순위 영역 */}
       <div className="mt-6 rounded-xl border border-[#E5E7EB] bg-white/70">
-        {/* 헤더: 제목 + 표시 인원 */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-[#E5E7EB]">
           <div className="text-[13px] text-[#111827]">전체 순위</div>
           <div className="text-[12px] text-[#6B7280]">
@@ -208,12 +226,11 @@ function RankingBoard({
           </div>
         </div>
 
-        {/* 리스트 */}
         <div className="p-4 space-y-3">
           {rest.map((item, index) => (
             <RowCard
               key={item.userId}
-              rank={index + 4} // 4위부터 시작
+              rank={index + 4}
               name={item.userName}
               score={
                 item.points ||
@@ -221,6 +238,7 @@ function RankingBoard({
                 item.totalFeedbackCount
               }
               profileImage={item.userPicture}
+              grade={item.grade}
             />
           ))}
           {loading && (
@@ -236,10 +254,8 @@ function RankingBoard({
           )}
         </div>
 
-        {/* 더보기 / 접기 버튼 */}
         <div className="px-4 pb-4">
           <div className="mx-auto max-w-[360px] flex items-center justify-center gap-3">
-            {/* 더보기 */}
             <button
               type="button"
               onClick={onLoadMore}
@@ -254,7 +270,6 @@ function RankingBoard({
               더보기
             </button>
 
-            {/* 접기 */}
             <button
               type="button"
               onClick={onCollapse}

--- a/src/components/leaderboard/RankingBoard.jsx
+++ b/src/components/leaderboard/RankingBoard.jsx
@@ -1,22 +1,21 @@
 import React, { useMemo, useState } from "react";
 import samplePosts from "../postcontext.jsx";
 import { TbCoin } from "react-icons/tb";
-import profile from "../../assets/profile.png";
-
-// 포인트 기준 내림차순으로 정렬해 랭킹 배열 생성
+import profile from "../../assets/baseProfile.png";
+import { makeAbsoluteImageUrl } from "../../utils/imageHelper";
 function rankByPoints(posts) {
   return [...posts]
     .sort((a, b) => b.points - a.points)
     .map((post, idx) => ({
-      rank: idx + 1, // 1부터 시작하는 등수
-      name: post.author, // 사용자 이름
-      score: post.points, // 포인트
-      profileImage: profile, // 임시 프로필 이미지 -> 추후 연동
+      rank: idx + 1,
+      name: post.author,
+      score: post.points,
+      profileImage: profile,
     }));
 }
 
-function RankingBoard() {
-  const ranked = useMemo(() => rankByPoints(samplePosts, profile), []);
+function RankingBoard({ leaders, loading }) {
+  const fullMockedRanked = useMemo(() => rankByPoints(samplePosts), []);
 
   const DEFAULT_COUNT = 10; // 기본 표시 인원
   const MAX_EXPANDED = 50; // 더보기로 펼칠 수 있는 최대 인원
@@ -24,27 +23,38 @@ function RankingBoard() {
   // 전체 순위에서 표시할 총 인원(Top3 포함)
   const [showCount, setShowCount] = useState(DEFAULT_COUNT);
 
-  // 상단 Top3 데이터(1~3위)
-  const top3 = ranked.slice(0, 3);
+  // 상단 Top3 데이터
+  const top3Leaders = leaders.slice(0, 3);
+  const first = top3Leaders[0];
+  const second = top3Leaders[1];
+  const third = top3Leaders[2];
 
-  // 실제로 표시 가능한 최대 인원(데이터 수와 상한 중 더 작은 값)
-  const maxShowable = Math.min(ranked.length, MAX_EXPANDED);
+  // 목록 데이터
+  const rest = fullMockedRanked.slice(
+    3,
+    Math.min(showCount, fullMockedRanked.length)
+  );
 
-  // 목록에서 4위 ~ showCount 까지 잘라낸 데이터
-  const rest = ranked.slice(3, Math.min(showCount, maxShowable));
-
-  // 버튼 활성/비활성 판단 값
-  const isAtDefault = showCount === DEFAULT_COUNT; // 접기 비활성 조건(이미 기본 상태)
-  const isAtMax = showCount >= maxShowable; // 더보기 비활성 조건(이미 최대로 펼친 상태)
-
-  // 더보기: 한 번에 maxShowable 까지 펼침
+  const maxShowable = Math.min(fullMockedRanked.length, MAX_EXPANDED);
+  const isAtDefault = showCount === DEFAULT_COUNT;
+  const isAtMax = showCount >= maxShowable;
   const handleMore = () => setShowCount(maxShowable);
-
-  // 접기: 기본 인원으로 복귀
   const handleCollapse = () => setShowCount(DEFAULT_COUNT);
 
-  // 상단 TOP 3 전용 카드
-  const TopCard = ({ rank, name, score, profileImage, tone = "neutral" }) => {
+  // 상단 Top 3 전용 카드
+  const TopCard = ({
+    rank,
+    name,
+    score,
+    profileImage,
+    grade,
+    tone = "neutral",
+  }) => {
+    const displayScore = score || 0;
+    const absoluteImageUrl = profileImage
+      ? makeAbsoluteImageUrl(profileImage)
+      : profile;
+
     const toneMap = {
       gold: "bg-[#FEF9C3] border-[#FACC15]", // 1등
       silver: "bg-[#F3F4F6] border-[#D1D5DB]", // 2등
@@ -63,7 +73,7 @@ function RankingBoard() {
         {/* 프로필 이미지 */}
         <div className="mt-4 w-16 h-16 rounded-full bg-white/50 flex items-center justify-center border border-black/10 overflow-hidden">
           <img
-            src={profile}
+            src={absoluteImageUrl}
             alt={`${name} profile`}
             className="w-full h-full object-cover"
             draggable={false}
@@ -75,7 +85,7 @@ function RankingBoard() {
           <div className="text-[16px] font-semibold">{name}</div>
           <div className="flex items-center justify-center gap-1 text-[14px] text-[#4D4D4D] mt-1">
             <TbCoin size={14} />
-            {score.toLocaleString()}
+            {displayScore.toLocaleString()}
           </div>
         </div>
       </div>
@@ -83,46 +93,63 @@ function RankingBoard() {
   };
 
   // 4위 이하 일반 리스트용 카드
-  const RowCard = ({ rank, name, score, profileImage }) => (
-    <div className="flex items-center justify-between w-full px-10 py-4 rounded-xl bg-white border border-[#E5E7EB] shadow-sm">
-      {/* 왼쪽 영역 */}
-      <div className="flex items-center gap-4">
-        {/* 등수 배지 */}
-        <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[#F3F4F6] text-[#374151] text-[13px] font-bold">
-          {rank}
-        </span>
+  const RowCard = ({ rank, name, score, profileImage }) => {
+    const absoluteImageUrl = profileImage
+      ? makeAbsoluteImageUrl(profileImage)
+      : profile;
 
-        {/* 프로필 이미지 + 이름 */}
-        <div className="flex items-center gap-3">
-          <div className="w-8 h-8 rounded-full bg-[#F9FAFB] border border-[#E5E7EB] overflow-hidden">
-            <img
-              src={profile}
-              alt={`${name} profile`}
-              className="w-full h-full object-cover"
-              draggable={false}
-            />
+    return (
+      <div className="flex items-center justify-between w-full px-10 py-4 rounded-xl bg-white border border-[#E5E7EB] shadow-sm">
+        {/* 왼쪽 영역 */}
+        <div className="flex items-center gap-4">
+          {/* 등수 배지 */}
+          <span className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-[#F3F4F6] text-[#374151] text-[13px] font-bold">
+            {rank}
+          </span>
+
+          {/* 프로필 이미지 + 이름 */}
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 rounded-full bg-[#F9FAFB] border border-[#E5E7EB] overflow-hidden">
+              <img
+                src={absoluteImageUrl}
+                alt={`${name} profile`}
+                className="w-full h-full object-cover"
+                draggable={false}
+              />
+            </div>
+            <div className="text-[15px] font-semibold">{name}</div>
           </div>
-          <div className="text-[15px] font-semibold">{name}</div>
+
+          {/* 등급 배지 -> 추후 연동 */}
+          <span className="text-[11px] px-2 py-[2px] rounded-full bg-[#DBEAFE] text-[#193CB8]">
+            숲의 현자
+          </span>
         </div>
 
-        {/* 등급 배지 -> 추후 연동 */}
-        <span className="text-[11px] px-2 py-[2px] rounded-full bg-[#DBEAFE] text-[#193CB8]">
-          숲의 현자
-        </span>
+        {/* 오른쪽 영역: 포인트 */}
+        <div className="flex items-center justify-center gap-1 text-[14px] text-[#4D4D4D] mt-1">
+          <TbCoin size={13} />
+          {score.toLocaleString()}
+        </div>
       </div>
+    );
+  };
 
-      {/* 오른쪽 영역: 포인트 */}
-      <div className="flex items-center justify-center gap-1 text-[14px] text-[#4D4D4D] mt-1">
-        <TbCoin size={13} />
-        {score.toLocaleString()}
+  if (loading) {
+    return (
+      <div className="mt-12 text-center text-[#6B7280]">
+        <p>데이터를 불러오는 중입니다...</p>
       </div>
-    </div>
-  );
+    );
+  }
 
-  // Top3 개별 참조(가독성)
-  const first = top3[0];
-  const second = top3[1];
-  const third = top3[2];
+  if (top3Leaders.length === 0 && fullMockedRanked.length === 0) {
+    return (
+      <div className="mt-12 text-center text-[#6B7280]">
+        <p>😭 아직 리더보드 데이터가 없습니다.</p>
+      </div>
+    );
+  }
 
   return (
     <div className="mt-8">
@@ -134,13 +161,52 @@ function RankingBoard() {
 
         <div className="flex items-end justify-center gap-4">
           <div className="translate-y-2">
-            {second && <TopCard {...second} tone="silver" />}
+            {/* 2위: API 데이터 사용 */}
+            {second && (
+              <TopCard
+                rank={2}
+                name={second.userName}
+                score={
+                  second.points ||
+                  second.adoptedFeedbackCount ||
+                  second.totalFeedbackCount
+                }
+                profileImage={second.userPicture}
+                tone="silver"
+              />
+            )}
           </div>
           <div className="-translate-y-2">
-            {first && <TopCard {...first} tone="gold" />}
+            {/* 1위: API 데이터 사용 */}
+            {first && (
+              <TopCard
+                rank={1}
+                name={first.userName}
+                score={
+                  first.points ||
+                  first.adoptedFeedbackCount ||
+                  first.totalFeedbackCount
+                }
+                profileImage={first.userPicture}
+                tone="gold"
+              />
+            )}
           </div>
           <div className="translate-y-2">
-            {third && <TopCard {...third} tone="bronze" />}
+            {/* 3위: API 데이터 사용 */}
+            {third && (
+              <TopCard
+                rank={3}
+                name={third.userName}
+                score={
+                  third.points ||
+                  third.adoptedFeedbackCount ||
+                  third.totalFeedbackCount
+                }
+                profileImage={third.userPicture}
+                tone="bronze"
+              />
+            )}
           </div>
         </div>
       </div>
@@ -151,8 +217,9 @@ function RankingBoard() {
         <div className="flex items-center justify-between px-5 py-3 border-b border-[#E5E7EB]">
           <div className="text-[13px] text-[#111827]">전체 순위</div>
           <div className="text-[12px] text-[#6B7280]">
-            {/* 예: 123명 중 10명 표시 */}
-            {ranked.length}명 중 {Math.min(showCount, maxShowable)}명 표시
+            {/* 목업 데이터 전체 길이를 사용 */}
+            {fullMockedRanked.length}명 중 {Math.min(showCount, maxShowable)}명
+            표시
           </div>
         </div>
 
@@ -166,7 +233,7 @@ function RankingBoard() {
         {/* 더보기 / 접기 버튼 */}
         <div className="px-4 pb-4">
           <div className="mx-auto max-w-[360px] flex items-center justify-center gap-3">
-            {/* 더보기: 이미 최대로 펼쳐진 경우 비활성화 */}
+            {/* 더보기 */}
             <button
               type="button"
               onClick={handleMore}
@@ -181,7 +248,7 @@ function RankingBoard() {
               더보기
             </button>
 
-            {/* 접기: 이미 기본 상태면 비활성화 */}
+            {/* 접기 */}
             <button
               type="button"
               onClick={handleCollapse}

--- a/src/components/leaderboard/StatCard.jsx
+++ b/src/components/leaderboard/StatCard.jsx
@@ -3,7 +3,12 @@ import React from "react";
 // 리더보드 통계 지표 카드 컴포넌트
 function StatCard({ icon, value, unit, label }) {
   return (
-    <div className="flex flex-col items-start justify-center w-[260px] h-[138px] rounded-[10px] bg-white p-6 shadow-sm border border-[#E5E7EB]">
+    <div
+      className="flex flex-col items-start justify-center 
+    w-full min-w-[260px] max-w-[320px] 
+    h-[138px] rounded-[10px] bg-white p-6 
+    shadow-sm border border-[#E5E7EB]"
+    >
       <img src={icon} alt="icon" className="w-[30px] h-[30px] mb-2" />
       <div className="flex items-end gap-[2px]">
         <span className="text-[24px] font-medium">

--- a/src/pages/LeaderBoard.jsx
+++ b/src/pages/LeaderBoard.jsx
@@ -5,9 +5,12 @@ import LeaderboardTabs from "../components/leaderboard/LeaderboardTabs";
 import icon1 from "../assets/leaderboard_icon1.png";
 import icon2 from "../assets/leaderboard_icon2.png";
 import icon3 from "../assets/leaderboard_icon3.png";
-import icon4 from "../assets/leaderboard_icon4.png";
 import RankingBoard from "../components/leaderboard/RankingBoard.jsx";
-import { getTop3Leaders, getFullLeaders } from "../api/leaderboardApi";
+import {
+  getTop3Leaders,
+  getFullLeaders,
+  getWeeklyFeedbackCount,
+} from "../api/leaderboardApi";
 
 function LeaderBoard() {
   const PAGE_SIZE = 10; // 한 페이지당 가져올 데이터 수
@@ -22,15 +25,33 @@ function LeaderBoard() {
   const [loading, setLoading] = useState(true);
   const [currentCriteria, setCurrentCriteria] = useState("points");
 
-  // 상단 통계 카드 데이터 (추후 연동 필요)
+  // 이번 주 피드백 수
+  const [weeklyFeedbackCount, setWeeklyFeedbackCount] = useState(0);
+
+  // 상단 통계 카드 데이터
   const stats = [
     { icon: icon1, value: 24, unit: "명", label: "이번 주 신규 가드너" },
-    { icon: icon2, value: 127, unit: "%", label: "평균 성장률" },
-    { icon: icon3, value: 15670, unit: "점", label: "이번 달 최고 기록" },
-    { icon: icon4, value: 8.3, unit: "개", label: "평균 완료 과제" },
+    { icon: icon2, value: 127, unit: "개", label: "이번 주 게시글 수" },
+    {
+      icon: icon3,
+      value: weeklyFeedbackCount ?? 0,
+      unit: "개",
+      label: "이번 주 피드백 수",
+    },
   ];
 
-  // 데이터 로딩 함수
+  // 이번 주 피드백 수 로딩
+  const fetchWeeklyFeedback = async () => {
+    try {
+      const count = await getWeeklyFeedbackCount();
+      setWeeklyFeedbackCount(Number(count) || 0);
+    } catch (error) {
+      console.error("Failed to fetch weekly feedback count:", error);
+      setWeeklyFeedbackCount(0);
+    }
+  };
+
+  // 상위 3명 데이터 로딩 함수
   const fetchTop3Leaders = async (criteria) => {
     try {
       const data = await getTop3Leaders(criteria);
@@ -95,6 +116,7 @@ function LeaderBoard() {
   useEffect(() => {
     fetchTop3Leaders(currentCriteria);
     fetchFullLeaders(currentCriteria, 0);
+    fetchWeeklyFeedback();
   }, []);
 
   return (
@@ -110,8 +132,8 @@ function LeaderBoard() {
         </div>
 
         <div className="mx-auto max-w-[1080px] w-full">
-          {/* 지표 카드 4개 */}
-          <div className="mt-6 grid grid-cols-4 gap-3">
+          {/* 지표 카드 3개 */}
+          <div className="mt-8 mx-auto max-w-[900px] grid grid-cols-3 gap-5 place-items-center">
             {stats.map((item, idx) => (
               <StatCard
                 key={idx}

--- a/src/pages/LeaderBoard.jsx
+++ b/src/pages/LeaderBoard.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react"; // <-- useState, useEffect 추가
 import Header from "../components/header/Header";
 import StatCard from "../components/leaderboard/StatCard";
 import LeaderboardTabs from "../components/leaderboard/LeaderboardTabs";
@@ -7,8 +7,13 @@ import icon2 from "../assets/leaderboard_icon2.png";
 import icon3 from "../assets/leaderboard_icon3.png";
 import icon4 from "../assets/leaderboard_icon4.png";
 import RankingBoard from "../components/leaderboard/RankingBoard.jsx";
+import { getTop3Leaders } from "../api/leaderboardApi"; // <-- API import
 
 function LeaderBoard() {
+  const [top3Leaders, setTop3Leaders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [currentCriteria, setCurrentCriteria] = useState("points"); // 기본값: 누적 포인트
+
   // value값은 추후 연동해야함
   const stats = [
     { icon: icon1, value: 24, unit: "명", label: "이번 주 신규 가드너" },
@@ -16,6 +21,29 @@ function LeaderBoard() {
     { icon: icon3, value: 15670, unit: "점", label: "이번 달 최고 기록" },
     { icon: icon4, value: 8.3, unit: "개", label: "평균 완료 과제" },
   ];
+
+  // 데이터 로딩 함수
+  const fetchTop3Leaders = async (criteria) => {
+    setLoading(true);
+    try {
+      const data = await getTop3Leaders(criteria);
+      setTop3Leaders(data);
+    } catch (error) {
+      console.error("Failed to fetch top 3 leaders:", error);
+      setTop3Leaders([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCriteriaChange = (criteria) => {
+    setCurrentCriteria(criteria);
+    fetchTop3Leaders(criteria);
+  };
+
+  useEffect(() => {
+    fetchTop3Leaders(currentCriteria);
+  }, [currentCriteria]);
 
   return (
     <div className="min-h-screen bg-[#F9FAFB]">
@@ -44,10 +72,13 @@ function LeaderBoard() {
           </div>
 
           {/* 정렬 탭 */}
-          <LeaderboardTabs />
+          <LeaderboardTabs
+            currentCriteria={currentCriteria}
+            onCriteriaChange={handleCriteriaChange}
+          />
 
           {/* 랭킹보드 */}
-          <RankingBoard />
+          <RankingBoard leaders={top3Leaders} loading={loading} />
 
           {/* Footer */}
           <div className="w-full flex justify-center my-8">

--- a/src/pages/LeaderBoard.jsx
+++ b/src/pages/LeaderBoard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"; // <-- useState, useEffect 추가
+import React, { useState, useEffect } from "react";
 import Header from "../components/header/Header";
 import StatCard from "../components/leaderboard/StatCard";
 import LeaderboardTabs from "../components/leaderboard/LeaderboardTabs";
@@ -7,14 +7,22 @@ import icon2 from "../assets/leaderboard_icon2.png";
 import icon3 from "../assets/leaderboard_icon3.png";
 import icon4 from "../assets/leaderboard_icon4.png";
 import RankingBoard from "../components/leaderboard/RankingBoard.jsx";
-import { getTop3Leaders } from "../api/leaderboardApi"; // <-- API import
+import { getTop3Leaders, getFullLeaders } from "../api/leaderboardApi";
 
 function LeaderBoard() {
+  const PAGE_SIZE = 10; // 한 페이지당 가져올 데이터 수
   const [top3Leaders, setTop3Leaders] = useState([]);
+  const [fullLeaders, setFullLeaders] = useState([]);
+  const [pagingInfo, setPagingInfo] = useState({
+    totalPages: 1,
+    totalElements: 0,
+    currentPage: 0,
+    isLast: true,
+  });
   const [loading, setLoading] = useState(true);
-  const [currentCriteria, setCurrentCriteria] = useState("points"); // 기본값: 누적 포인트
+  const [currentCriteria, setCurrentCriteria] = useState("points");
 
-  // value값은 추후 연동해야함
+  // 상단 통계 카드 데이터 (추후 연동 필요)
   const stats = [
     { icon: icon1, value: 24, unit: "명", label: "이번 주 신규 가드너" },
     { icon: icon2, value: 127, unit: "%", label: "평균 성장률" },
@@ -24,26 +32,70 @@ function LeaderBoard() {
 
   // 데이터 로딩 함수
   const fetchTop3Leaders = async (criteria) => {
-    setLoading(true);
     try {
       const data = await getTop3Leaders(criteria);
       setTop3Leaders(data);
     } catch (error) {
       console.error("Failed to fetch top 3 leaders:", error);
       setTop3Leaders([]);
+    }
+  };
+
+  // 전체 순위 데이터 로딩 함수
+  const fetchFullLeaders = async (criteria, page) => {
+    if (page === 0) setLoading(true);
+
+    try {
+      const response = await getFullLeaders(criteria, page, PAGE_SIZE);
+      const newLeaders = response.content.slice(page === 0 ? 3 : 0);
+
+      setFullLeaders((prev) =>
+        page === 0 ? newLeaders : [...prev, ...newLeaders]
+      );
+
+      setPagingInfo({
+        totalPages: response.totalPages,
+        totalElements: response.totalElements,
+        currentPage: response.number,
+        isLast: response.last,
+      });
+    } catch (error) {
+      console.error("Failed to fetch full leaders:", error);
     } finally {
-      setLoading(false);
+      if (page === 0) setLoading(false);
     }
   };
 
   const handleCriteriaChange = (criteria) => {
     setCurrentCriteria(criteria);
     fetchTop3Leaders(criteria);
+    fetchFullLeaders(criteria, 0);
+  };
+
+  //  더보기 버튼 핸들러
+  const handleLoadMore = () => {
+    if (!pagingInfo.isLast) {
+      fetchFullLeaders(currentCriteria, pagingInfo.currentPage + 1);
+    }
+  };
+
+  // 접기 버튼 핸들러
+  const handleCollapse = () => {
+    const DEFAULT_DISPLAY_COUNT = PAGE_SIZE - 3;
+    const firstPageLeaders = fullLeaders.slice(0, DEFAULT_DISPLAY_COUNT);
+
+    setFullLeaders(firstPageLeaders);
+    setPagingInfo((prev) => ({
+      ...prev,
+      currentPage: 0,
+      isLast: prev.totalElements <= PAGE_SIZE,
+    }));
   };
 
   useEffect(() => {
     fetchTop3Leaders(currentCriteria);
-  }, [currentCriteria]);
+    fetchFullLeaders(currentCriteria, 0);
+  }, []);
 
   return (
     <div className="min-h-screen bg-[#F9FAFB]">
@@ -78,7 +130,15 @@ function LeaderBoard() {
           />
 
           {/* 랭킹보드 */}
-          <RankingBoard leaders={top3Leaders} loading={loading} />
+          <RankingBoard
+            leaders={top3Leaders}
+            loading={loading}
+            fullLeaders={fullLeaders}
+            totalElements={pagingInfo.totalElements}
+            isLast={pagingInfo.isLast}
+            onLoadMore={handleLoadMore}
+            onCollapse={handleCollapse}
+          />
 
           {/* Footer */}
           <div className="w-full flex justify-center my-8">
@@ -91,7 +151,8 @@ function LeaderBoard() {
                 </span>
               </div>
               <p className="text-[12px] text-[#4A5565]">
-                총 15명의 개발자가 함께 코드를 키우고 있습니다
+                총 {pagingInfo.totalElements}명의 개발자가 함께 코드를 키우고
+                있습니다
               </p>
             </div>
           </div>

--- a/src/pages/LeaderBoard.jsx
+++ b/src/pages/LeaderBoard.jsx
@@ -9,11 +9,11 @@ import RankingBoard from "../components/leaderboard/RankingBoard.jsx";
 import {
   getTop3Leaders,
   getFullLeaders,
-  getWeeklyFeedbackCount,
+  getWeeklyStats,
 } from "../api/leaderboardApi";
 
 function LeaderBoard() {
-  const PAGE_SIZE = 10; // 한 페이지당 가져올 데이터 수
+  const PAGE_SIZE = 10;
   const [top3Leaders, setTop3Leaders] = useState([]);
   const [fullLeaders, setFullLeaders] = useState([]);
   const [pagingInfo, setPagingInfo] = useState({
@@ -25,29 +25,51 @@ function LeaderBoard() {
   const [loading, setLoading] = useState(true);
   const [currentCriteria, setCurrentCriteria] = useState("points");
 
-  // 이번 주 피드백 수
-  const [weeklyFeedbackCount, setWeeklyFeedbackCount] = useState(0);
+  // 이번 주 통계 (신규 가드너 / 게시글 / 피드백)
+  const [weeklyStats, setWeeklyStats] = useState({
+    newUsersCount: 0,
+    newPostsCount: 0,
+    newFeedbacksCount: 0,
+  });
 
   // 상단 통계 카드 데이터
   const stats = [
-    { icon: icon1, value: 24, unit: "명", label: "이번 주 신규 가드너" },
-    { icon: icon2, value: 127, unit: "개", label: "이번 주 게시글 수" },
+    {
+      icon: icon1,
+      value: weeklyStats.newUsersCount ?? 0,
+      unit: "명",
+      label: "이번 주 신규 가드너",
+    },
+    {
+      icon: icon2,
+      value: weeklyStats.newPostsCount ?? 0,
+      unit: "개",
+      label: "이번 주 게시글 수",
+    },
     {
       icon: icon3,
-      value: weeklyFeedbackCount ?? 0,
+      value: weeklyStats.newFeedbacksCount ?? 0,
       unit: "개",
       label: "이번 주 피드백 수",
     },
   ];
 
-  // 이번 주 피드백 수 로딩
-  const fetchWeeklyFeedback = async () => {
+  // 이번 주 통계 로딩
+  const fetchWeeklyStatsData = async () => {
     try {
-      const count = await getWeeklyFeedbackCount();
-      setWeeklyFeedbackCount(Number(count) || 0);
+      const data = await getWeeklyStats();
+      setWeeklyStats({
+        newUsersCount: Number(data.newUsersCount) || 0,
+        newPostsCount: Number(data.newPostsCount) || 0,
+        newFeedbacksCount: Number(data.newFeedbacksCount) || 0,
+      });
     } catch (error) {
-      console.error("Failed to fetch weekly feedback count:", error);
-      setWeeklyFeedbackCount(0);
+      console.error("Failed to fetch weekly stats:", error);
+      setWeeklyStats({
+        newUsersCount: 0,
+        newPostsCount: 0,
+        newFeedbacksCount: 0,
+      });
     }
   };
 
@@ -116,7 +138,7 @@ function LeaderBoard() {
   useEffect(() => {
     fetchTop3Leaders(currentCriteria);
     fetchFullLeaders(currentCriteria, 0);
-    fetchWeeklyFeedback();
+    fetchWeeklyStatsData();
   }, []);
 
   return (


### PR DESCRIPTION
# Pull Request

## 📝 변경 사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 설명해주세요 -->
- 리더보드 페이지 API 연동

## 🔧 주요 변경 내용
<!-- 주요 변경사항들을 나열해주세요 -->
#### 1. 상단 통계 영역 API 연동
- 이번 주 신규 가드너 수
- 이번 주 게시글 수
- 이번 주 피드백 수  
#### 2. 정렬 순서에 따라 사용자 목록 조회
- 정렬 : 누적 포인트, 주간 피드백 채택 수, 주간 피드백 등록 수
- Top3 영역 : 상위 3명의 사용자 정보 표시
- 4등~10등까지 기본으로 사용자 정보 표시
- 10위부터 : 더보기 버튼 활성화
- 등급 뱃지 : 새싹 개발자 < 잎새 개발자 < 나무 개발자 < 숲의 현자
#### 3. 사용자 카드 클릭 시 사용자 상세페이지로 이동
- 클릭한 사용자의 userId를 이용해서 `/my-paged/{userId}` 경로로 이동
## 📸 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
<img width="1578" height="2050" alt="localhost_3000_leader-board" src="https://github.com/user-attachments/assets/36ebd9ce-7047-45b4-9ec3-b02cff45c364" />